### PR TITLE
#64 UseDatabaseNullSemantics is now read directly from configuration …

### DIFF
--- a/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/DataStructure/DomInitializationCodeGenerator.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/DataStructure/DomInitializationCodeGenerator.cs
@@ -66,8 +66,7 @@ namespace Rhetos.Dom.DefaultConcepts
 
             codeBuilder.InsertCode(GenerateCommonClassesSnippet());
 
-            if (_configuration.GetBool("EntityFramework.UseDatabaseNullSemantics", false).Value == true)
-                codeBuilder.InsertCode("this.Configuration.UseDatabaseNullSemantics = true;\r\n            ", EntityFrameworkContextInitializeTag);
+            codeBuilder.InsertCode("this.Configuration.UseDatabaseNullSemantics = _configuration.GetBool(\"EntityFramework.UseDatabaseNullSemantics\", false).Value;\r\n            ", EntityFrameworkContextInitializeTag);
 
             // Types used in the preceding code snippet:
             codeBuilder.AddReferencesFromDependency(typeof(Autofac.Module)); // Includes a reference to Autofac.dll.
@@ -163,12 +162,16 @@ namespace Common
 
     public class EntityFrameworkContext : System.Data.Entity.DbContext, Rhetos.Persistence.IPersistenceCache
     {{
+        private readonly Rhetos.Utilities.IConfiguration _configuration;
+
         public EntityFrameworkContext(
             Rhetos.Persistence.IPersistenceTransaction persistenceTransaction,
             Rhetos.Dom.DefaultConcepts.Persistence.EntityFrameworkMetadata metadata,
-            EntityFrameworkConfiguration configuration) // EntityFrameworkConfiguration is provided as an IoC dependency for EntityFrameworkContext in order to initialize the global DbConfiguration before using DbContext.
+            EntityFrameworkConfiguration entityFrameworkConfiguration, // EntityFrameworkConfiguration is provided as an IoC dependency for EntityFrameworkContext in order to initialize the global DbConfiguration before using DbContext.
+            Rhetos.Utilities.IConfiguration configuration)
             : base(new System.Data.Entity.Core.EntityClient.EntityConnection(metadata.MetadataWorkspace, persistenceTransaction.Connection), false)
         {{
+            _configuration = configuration;
             Initialize();
             Database.UseTransaction(persistenceTransaction.Transaction);
         }}
@@ -179,9 +182,11 @@ namespace Common
         /// </summary>
         protected EntityFrameworkContext(
             System.Data.Common.DbConnection connection,
-            EntityFrameworkConfiguration configuration) // EntityFrameworkConfiguration is provided as an IoC dependency for EntityFrameworkContext in order to initialize the global DbConfiguration before using DbContext.
+            EntityFrameworkConfiguration entityFrameworkConfiguration, // EntityFrameworkConfiguration is provided as an IoC dependency for EntityFrameworkContext in order to initialize the global DbConfiguration before using DbContext.
+            Rhetos.Utilities.IConfiguration configuration)
             : base(connection, true)
         {{
+            _configuration = configuration;
             Initialize();
         }}
 

--- a/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/Persistence/EntityFrameworkGenerateMetadataFiles.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/Persistence/EntityFrameworkGenerateMetadataFiles.cs
@@ -47,13 +47,20 @@ namespace Rhetos.Dom.DefaultConcepts.Persistence
         private readonly IDomainObjectModel _dom;
         private readonly ConnectionString _connectionString;
         private readonly GeneratedFilesCache _cache;
+        private readonly IConfiguration _configuration;
 
-        public EntityFrameworkGenerateMetadataFiles(ILogProvider logProvider, IDomainObjectModel dom, ConnectionString connectionString, GeneratedFilesCache cache)
+        public EntityFrameworkGenerateMetadataFiles(
+            ILogProvider logProvider, 
+            IDomainObjectModel dom, 
+            ConnectionString connectionString, 
+            GeneratedFilesCache cache,
+            IConfiguration configuration)
         {
             _performanceLogger = logProvider.GetLogger("Performance");
             _dom = dom;
             _connectionString = connectionString;
             _cache = cache;
+            _configuration = configuration;
         }
 
         public IEnumerable<string> Dependencies
@@ -82,8 +89,8 @@ namespace Rhetos.Dom.DefaultConcepts.Persistence
                     .Invoke(new object[] { });
 
                 var dbContext = (DbContext)_dom.GetType("Common.EntityFrameworkContext")
-                    .GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, new[] { typeof(DbConnection), dbConfiguration.GetType() }, null)
-                    .Invoke(new object[] { connection, dbConfiguration });
+                    .GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, new[] { typeof(DbConnection), dbConfiguration.GetType(), typeof(IConfiguration) }, null)
+                    .Invoke(new object[] { connection, dbConfiguration, _configuration });
 
                 string edmx;
                 using (var stringWriter = new StringWriter())


### PR DESCRIPTION
…at runtime.

Renamed old variable 'configuration' to 'entityFrameworkConfiguration', due to a naming conflict for IConfiguration type