### PR TITLE
Refactoring db index concepts to macro concepts.

### DIFF
--- a/CommonConcepts/CommonConceptsTest/DslScripts/SqlWorkarounds.rhe
+++ b/CommonConcepts/CommonConceptsTest/DslScripts/SqlWorkarounds.rhe
@@ -143,6 +143,20 @@ Module TestSqlWorkarounds
 	{
 		SqlDependsOnIndex TestSqlWorkarounds.TestIndex.'A B';
 	}
+
+	Entity RedundantIndexDefinitions1
+	{
+		// This is just a deploy-time test. The deployment would fail if there is a conflict between multiple index definitions.
+		SqlIndexMultiple 'Code' { Clustered; }
+		ShortString Code { AutoCode; SqlIndex; Unique; }
+	}
+
+	Entity RedundantIndexDefinitions2
+	{
+		// This is just a deploy-time test. The deployment would fail if there is a conflict between multiple index definitions.
+		SqlIndexMultiple 'TestIndex' { Clustered; }
+		Reference TestIndex { Unique; SqlIndex; Detail; }
+	}
 }
 
 Module TestSqlWorkarounds2

--- a/CommonConcepts/DataMigration/2.12/1 - Optimized index CreateQuery modification.sql
+++ b/CommonConcepts/DataMigration/2.12/1 - Optimized index CreateQuery modification.sql
@@ -1,0 +1,60 @@
+/*DATAMIGRATION F0F1C9B6-058D-41DF-8514-DF9D7BD2D701*/ -- Change the script's code only if it needs to be executed again.
+
+/*
+This data-migration script manually adds a new option in the CreateQuery for indexes.
+This will prevent Rhetos from automatically changing CreateQuery to the new version,
+in order to avoid re-creating the indexes that might take long time on large databases.
+*/
+
+SELECT
+    NewCreateQuery = CASE WHEN CHARINDEX('CLUSTERED ' + Tag1, CreateQuery) <> 0
+        THEN REPLACE(CreateQuery, 'CLUSTERED ' + Tag1, Tag0 + ' CLUSTERED ' + Tag1)
+        ELSE REPLACE(CreateQuery, Tag1, Tag0 + ' ' + Tag1)
+        END,
+    *
+INTO #updates
+FROM
+    (
+        SELECT
+            Tag0 = '/*SqlIndexMultipleInfo Options0 ' + KeyProperties + '*/',
+            Tag1 = '/*SqlIndexMultipleInfo Options1 ' + KeyProperties + '*/',
+            *
+        FROM
+            (
+                SELECT
+                    ID,
+                    CreateQuery,
+                    KeyProperties = SUBSTRING(ConceptInfoKey, 22, LEN(ConceptInfoKey))
+                FROM
+                    Rhetos.AppliedConcept
+                WHERE
+                    ConceptInfoKey LIKE 'SqlIndexMultipleInfo %'
+            ) x
+    ) x
+WHERE
+    CreateQuery NOT LIKE '%' + Tag0 + '%'
+
+UPDATE
+    ac
+SET
+    CreateQuery = #updates.NewCreateQuery
+FROM
+    Rhetos.AppliedConcept ac
+    INNER JOIN #updates ON #updates.ID = ac.ID;
+
+UPDATE
+    Rhetos.AppliedConcept
+SET
+    InfoType = REPLACE(InfoType, 'UniqueMultiplePropertiesInfo', 'SqlIndexMultipleInfo'),
+    SerializedInfo = REPLACE(SerializedInfo, 'UniqueMultiplePropertiesInfo', 'SqlIndexMultipleInfo')
+WHERE
+    ImplementationType LIKE 'Rhetos.DatabaseGenerator.DefaultConcepts.SqlIndexMultipleDatabaseDefinition%';
+
+DELETE
+    d
+FROM
+    Rhetos.AppliedConceptDependsOn d
+    INNER JOIN Rhetos.AppliedConcept c ON c.ID = d.DependsOnID
+WHERE
+    c.InfoType LIKE 'Rhetos.Dsl.DefaultConcepts.UniqueMultiplePropertiesInfo%'
+    and c.CreateQuery = '';

--- a/CommonConcepts/Plugins/Rhetos.DatabaseGenerator.DefaultConcepts/Sql.MsSql.resx
+++ b/CommonConcepts/Plugins/Rhetos.DatabaseGenerator.DefaultConcepts/Sql.MsSql.resx
@@ -365,7 +365,7 @@ CREATE FUNCTION {0}.{1} ({2})
     <value>IX_{0}_{1}</value>
   </data>
   <data name="SqlIndexMultipleDatabaseDefinition_Create" xml:space="preserve">
-    <value>CREATE {4} INDEX {0} ON {1}.{2} ({3}) {5}</value>
+    <value>CREATE {4} {5} INDEX {0} ON {1}.{2} ({3}) {6}</value>
   </data>
   <data name="SqlIndexMultipleDatabaseDefinition_Remove" xml:space="preserve">
     <value>DROP INDEX {0}.{1}.{2}</value>

--- a/CommonConcepts/Plugins/Rhetos.DatabaseGenerator.DefaultConcepts/Sql.Oracle.resx
+++ b/CommonConcepts/Plugins/Rhetos.DatabaseGenerator.DefaultConcepts/Sql.Oracle.resx
@@ -217,7 +217,7 @@ END;</value>
     <value>ALTER TABLE {0} DROP CONSTRAINT {1}</value>
   </data>
   <data name="SqlIndexMultipleDatabaseDefinition_Create" xml:space="preserve">
-    <value>CREATE {4} INDEX {1}.{0} ON {1}.{2} ({3}) {5}</value>
+    <value>CREATE {4} {5} INDEX {1}.{0} ON {1}.{2} ({3}) {6}</value>
   </data>
   <data name="SqlIndexMultipleDatabaseDefinition_Remove" xml:space="preserve">
     <value>DROP INDEX {0}.{2}</value>

--- a/CommonConcepts/Plugins/Rhetos.DatabaseGenerator.DefaultConcepts/SqlIndexMultipleDatabaseDefinition.cs
+++ b/CommonConcepts/Plugins/Rhetos.DatabaseGenerator.DefaultConcepts/SqlIndexMultipleDatabaseDefinition.cs
@@ -37,7 +37,11 @@ namespace Rhetos.DatabaseGenerator.DefaultConcepts
     public class SqlIndexMultipleDatabaseDefinition : IConceptDatabaseDefinition
     {
         /// <summary>
-        /// Options inserted between CREATE and INDEX
+        /// Options inserted between CREATE and INDEX, before Options1Tag.
+        /// </summary>
+        public static readonly SqlTag<SqlIndexMultipleInfo> Options0Tag = "Options0";
+        /// <summary>
+        /// Options inserted between CREATE and INDEX, after Options0Tag.
         /// </summary>
         public static readonly SqlTag<SqlIndexMultipleInfo> Options1Tag = "Options1";
         /// <summary>
@@ -68,6 +72,7 @@ namespace Rhetos.DatabaseGenerator.DefaultConcepts
                     SqlUtility.Identifier(info.DataStructure.Module.Name),
                     SqlUtility.Identifier(info.DataStructure.Name),
                     ColumnsTag.Evaluate(info),
+                    Options0Tag.Evaluate(info),
                     Options1Tag.Evaluate(info),
                     Options2Tag.Evaluate(info));
             return null;

--- a/CommonConcepts/Plugins/Rhetos.DatabaseGenerator.DefaultConcepts/UniqueMultiplePropertiesDatabaseDefinition.cs
+++ b/CommonConcepts/Plugins/Rhetos.DatabaseGenerator.DefaultConcepts/UniqueMultiplePropertiesDatabaseDefinition.cs
@@ -50,8 +50,8 @@ namespace Rhetos.DatabaseGenerator.DefaultConcepts
             var info = (UniqueMultiplePropertiesInfo)conceptInfo;
             createdDependencies = null;
 
-            if (info.SqlImplementation())
-                codeBuilder.InsertCode(Sql.Get("SqlUniqueMultipleDatabaseDefinition_ExtendOption1"), SqlIndexMultipleDatabaseDefinition.Options1Tag, info);
+            if (info.Dependency_SqlIndex.SqlImplementation())
+                codeBuilder.InsertCode(Sql.Get("SqlUniqueMultipleDatabaseDefinition_ExtendOption1"), SqlIndexMultipleDatabaseDefinition.Options0Tag, info.Dependency_SqlIndex);
         }
     }
 }

--- a/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/SimpleBusinessLogic/UniqueMultiplePropertiesCodeGenerator.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/SimpleBusinessLogic/UniqueMultiplePropertiesCodeGenerator.cs
@@ -44,7 +44,7 @@ namespace Rhetos.Dom.DefaultConcepts.SimpleBusinessLogic
 
         public static bool ImplementInObjectModel(UniqueMultiplePropertiesInfo info)
         {
-            return !info.SqlImplementation() && info.DataStructure is IWritableOrmDataStructure;
+            return !info.Dependency_SqlIndex.SqlImplementation() && info.DataStructure is IWritableOrmDataStructure;
         }
 
         public void GenerateCode(IConceptInfo conceptInfo, ICodeBuilder codeBuilder)
@@ -57,13 +57,13 @@ namespace Rhetos.Dom.DefaultConcepts.SimpleBusinessLogic
                 codeBuilder.AddReferencesFromDependency(typeof(UserException));
             }
 
-            if (info.SqlImplementation() && info.DataStructure is IWritableOrmDataStructure)
+            if (info.Dependency_SqlIndex.SqlImplementation() && info.DataStructure is IWritableOrmDataStructure)
             {
                 var ormDataStructure = (IWritableOrmDataStructure)info.DataStructure;
                 string systemMessage = "DataStructure:" + info.DataStructure + ",Property:" + info.PropertyNames;
                 string interpretSqlError = @"if (interpretedException is Rhetos.UserException && Rhetos.Utilities.MsSqlUtility.IsUniqueError(interpretedException, "
                     + CsUtility.QuotedString(ormDataStructure.GetOrmSchema() + "." + ormDataStructure.GetOrmDatabaseObject()) + @", "
-                    + CsUtility.QuotedString(SqlIndexMultipleDatabaseDefinition.ConstraintName(info)) + @"))
+                    + CsUtility.QuotedString(SqlIndexMultipleDatabaseDefinition.ConstraintName(info.Dependency_SqlIndex)) + @"))
                     ((Rhetos.UserException)interpretedException).SystemMessage = " + CsUtility.QuotedString(systemMessage) + @";
                 ";
                 codeBuilder.InsertCode(interpretSqlError, WritableOrmDataStructureCodeGenerator.OnDatabaseErrorTag, info.DataStructure);

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/Advanced/EntityHistoryInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/Advanced/EntityHistoryInfo.cs
@@ -101,7 +101,7 @@ namespace Rhetos.Dsl.DefaultConcepts
                 new RequiredPropertyInfo { Property = currentProperty }, // TODO: SystemRequired
                 new PropertyFromInfo { Destination = Dependency_ChangesEntity, Source = activeSinceProperty },
                 historyActiveSinceProperty,
-                new UniquePropertiesInfo { DataStructure = Dependency_ChangesEntity, Property1 = currentProperty, Property2 = historyActiveSinceProperty }
+                new UniqueMultiplePropertiesInfo { DataStructure = Dependency_ChangesEntity, PropertyNames = $"{currentProperty.Name} {historyActiveSinceProperty.Name}" }
             });
 
             // InvalidData for history entity: it is not allowed to save with ActiveSince newer than current entity

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/Advanced/HierarchyInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/Advanced/HierarchyInfo.cs
@@ -181,7 +181,7 @@ namespace Rhetos.Dsl.DefaultConcepts
                 new PersistedAllPropertiesInfo { Persisted = persistedDataStructure }, // This will copy all properties from computedDataStructure.
                 new PersistedKeepSynchronizedInfo { Persisted = persistedDataStructure },
                 persistedLeftIndexProperty,
-                new SqlIndexInfo { Property = persistedLeftIndexProperty },
+                new SqlIndexMultipleInfo { DataStructure = persistedLeftIndexProperty.DataStructure, PropertyNames = persistedLeftIndexProperty.Name },
 
                 // Implement filters for finding ancestors and descendants, using indexed persisted data:
                 filterAncestorsParameter,

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DataStructure/DataStructureInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DataStructure/DataStructureInfo.cs
@@ -37,12 +37,14 @@ namespace Rhetos.Dsl.DefaultConcepts
 
         public override string ToString()
         {
-            return Module.Name + "." + Name;
+            return FullName; // For backward compatibility.
         }
 
         public override int GetHashCode()
         {
             return Name.GetHashCode();
         }
+
+        public string FullName => Module.Name + "." + Name;
     }
 }

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DataStructure/Properties/PropertyInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DataStructure/Properties/PropertyInfo.cs
@@ -39,7 +39,7 @@ namespace Rhetos.Dsl.DefaultConcepts
 
         public override string ToString()
         {
-            return DataStructure.ToString() + "." + Name;
+            return FullName; // For backward compatibility.
         }
 
         public override int GetHashCode()
@@ -56,5 +56,7 @@ namespace Rhetos.Dsl.DefaultConcepts
         {
             return Name;
         }
+
+        public string FullName => DataStructure.FullName + "." + Name;
     }
 }

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DatabaseWorkarounds/SqlDependsOnPropertyInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DatabaseWorkarounds/SqlDependsOnPropertyInfo.cs
@@ -41,8 +41,8 @@ namespace Rhetos.Dsl.DefaultConcepts
         public IEnumerable<IConceptInfo> CreateNewConcepts(SqlDependsOnPropertyInfo conceptInfo, IDslModel existingConcepts)
         {
             return existingConcepts.FindByReference<UniqueMultiplePropertiesInfo>(unique => unique.DataStructure, conceptInfo.DependsOn.DataStructure)
-                .Where(unique => unique.SqlImplementation() && IsFirstIdentifierInList(conceptInfo.DependsOn.Name, unique.PropertyNames))
-                .Select(unique => new SqlDependsOnSqlIndexInfo { Dependent = conceptInfo.Dependent, DependsOn = unique });
+                .Where(unique => unique.Dependency_SqlIndex.SqlImplementation() && IsFirstIdentifierInList(conceptInfo.DependsOn.Name, unique.PropertyNames))
+                .Select(unique => new SqlDependsOnSqlIndexInfo { Dependent = conceptInfo.Dependent, DependsOn = unique.Dependency_SqlIndex });
         }
 
         private static bool IsFirstIdentifierInList(string identifier, string list)

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DatabaseWorkarounds/SqlIndex2Info.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DatabaseWorkarounds/SqlIndex2Info.cs
@@ -27,7 +27,7 @@ namespace Rhetos.Dsl.DefaultConcepts
 {
     [Export(typeof(IConceptInfo))]
     [ConceptKeyword("SqlIndex")]
-    public class SqlIndex2Info : IConceptInfo, IValidationConcept, IMacroConcept
+    public class SqlIndex2Info : IValidatedConcept
     {
         [ConceptKey]
         public EntityInfo DataStructure { get; set; }
@@ -36,35 +36,26 @@ namespace Rhetos.Dsl.DefaultConcepts
         [ConceptKey]
         public PropertyInfo Property2 { get; set; }
 
-        public void CheckSemantics(IEnumerable<IConceptInfo> concepts)
+        public void CheckSemantics(IDslModel existingConcepts)
         {
-            if (Property1.DataStructure != DataStructure)
-                throw new Exception(string.Format(
-                    "SqlIndex is not well defined because property {0}.{1}.{2} is not in entity {3}.{4}.",
-                    Property1.DataStructure.Module.Name,
-                    Property1.DataStructure.Name,
-                    Property1.Name,
-                    DataStructure.Module.Name,
-                    DataStructure.Name));
-
-            if (Property2.DataStructure != DataStructure)
-                throw new Exception(string.Format(
-                    "SqlIndex is not well defined because property {0}.{1}.{2} is not in entity {3}.{4}.",
-                    Property2.DataStructure.Module.Name,
-                    Property2.DataStructure.Name,
-                    Property2.Name,
-                    DataStructure.Module.Name,
-                    DataStructure.Name));
+            DslUtility.CheckIfPropertyBelongsToDataStructure(Property1, DataStructure, this);
+            DslUtility.CheckIfPropertyBelongsToDataStructure(Property2, DataStructure, this);
         }
+    }
 
-        public SqlIndexMultipleInfo GetCreatedIndex()
+    [Export(typeof(IConceptMacro))]
+    public class SqlIndex2Macro : IConceptMacro<SqlIndex2Info>
+    {
+        public IEnumerable<IConceptInfo> CreateNewConcepts(SqlIndex2Info conceptInfo, IDslModel existingConcepts)
         {
-            return new SqlIndexMultipleInfo { DataStructure = DataStructure, PropertyNames = Property1.Name + " " + Property2.Name };
-        }
-
-        public IEnumerable<IConceptInfo> CreateNewConcepts(IEnumerable<IConceptInfo> existingConcepts)
-        {
-            return new[] { GetCreatedIndex() };
+            return new[]
+            {
+                new SqlIndexMultipleInfo
+                {
+                    DataStructure = conceptInfo.DataStructure,
+                    PropertyNames = conceptInfo.Property1.Name + " " + conceptInfo.Property2.Name
+                }
+            };
         }
     }
 }

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DatabaseWorkarounds/SqlIndex3Info.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DatabaseWorkarounds/SqlIndex3Info.cs
@@ -27,7 +27,7 @@ namespace Rhetos.Dsl.DefaultConcepts
 {
     [Export(typeof(IConceptInfo))]
     [ConceptKeyword("SqlIndex")]
-    public class SqlIndex3Info : IConceptInfo, IValidationConcept, IMacroConcept
+    public class SqlIndex3Info : IValidatedConcept
     {
         [ConceptKey]
         public EntityInfo DataStructure { get; set; }
@@ -38,44 +38,27 @@ namespace Rhetos.Dsl.DefaultConcepts
         [ConceptKey]
         public PropertyInfo Property3 { get; set; }
 
-        public void CheckSemantics(IEnumerable<IConceptInfo> concepts)
+        public void CheckSemantics(IDslModel existingConcepts)
         {
-            if (Property1.DataStructure != DataStructure)
-                throw new Exception(string.Format(
-                    "SqlIndex is not well defined because property {0}.{1}.{2} is not in entity {3}.{4}.",
-                    Property1.DataStructure.Module.Name,
-                    Property1.DataStructure.Name,
-                    Property1.Name,
-                    DataStructure.Module.Name,
-                    DataStructure.Name));
-
-            if (Property2.DataStructure != DataStructure)
-                throw new Exception(string.Format(
-                    "SqlIndex is not well defined because property {0}.{1}.{2} is not in entity {3}.{4}.",
-                    Property2.DataStructure.Module.Name,
-                    Property2.DataStructure.Name,
-                    Property2.Name,
-                    DataStructure.Module.Name,
-                    DataStructure.Name));
-
-            if (Property3.DataStructure != DataStructure)
-                throw new Exception(string.Format(
-                    "SqlIndex is not well defined because property {0}.{1}.{2} is not in entity {3}.{4}.",
-                    Property3.DataStructure.Module.Name,
-                    Property3.DataStructure.Name,
-                    Property3.Name,
-                    DataStructure.Module.Name,
-                    DataStructure.Name));
+            DslUtility.CheckIfPropertyBelongsToDataStructure(Property1, DataStructure, this);
+            DslUtility.CheckIfPropertyBelongsToDataStructure(Property2, DataStructure, this);
+            DslUtility.CheckIfPropertyBelongsToDataStructure(Property3, DataStructure, this);
         }
+    }
 
-        public SqlIndexMultipleInfo GetCreatedIndex()
+    [Export(typeof(IConceptMacro))]
+    public class SqlIndex3Macro : IConceptMacro<SqlIndex3Info>
+    {
+        public IEnumerable<IConceptInfo> CreateNewConcepts(SqlIndex3Info conceptInfo, IDslModel existingConcepts)
         {
-            return new SqlIndexMultipleInfo { DataStructure = DataStructure, PropertyNames = Property1.Name + " " + Property2.Name + " " + Property3.Name };
-        }
-
-        public IEnumerable<IConceptInfo> CreateNewConcepts(IEnumerable<IConceptInfo> existingConcepts)
-        {
-            return new[] { GetCreatedIndex() };
+            return new[]
+            {
+                new SqlIndexMultipleInfo
+                {
+                    DataStructure = conceptInfo.DataStructure,
+                    PropertyNames = conceptInfo.Property1.Name + " " + conceptInfo.Property2.Name + " " + conceptInfo.Property3.Name
+                }
+            };
         }
     }
 }

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DatabaseWorkarounds/SqlIndexInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DatabaseWorkarounds/SqlIndexInfo.cs
@@ -27,24 +27,25 @@ namespace Rhetos.Dsl.DefaultConcepts
 {
     [Export(typeof(IConceptInfo))]
     [ConceptKeyword("SqlIndex")]
-    public class SqlIndexInfo : IConceptInfo, IValidationConcept, IMacroConcept
+    public class SqlIndexInfo : IConceptInfo
     {
         [ConceptKey]
         public PropertyInfo Property { get; set; }
+    }
 
-        public void CheckSemantics(IEnumerable<IConceptInfo> concepts)
+    [Export(typeof(IConceptMacro))]
+    public class SqlIndexMacro : IConceptMacro<SqlIndexInfo>
+    {
+        public IEnumerable<IConceptInfo> CreateNewConcepts(SqlIndexInfo conceptInfo, IDslModel existingConcepts)
         {
-            SqlIndexMultipleInfo.CheckIfSupported(Property.DataStructure, this);
-        }
-
-        public SqlIndexMultipleInfo GetCreatedIndex()
-        {
-            return new SqlIndexMultipleInfo { DataStructure = Property.DataStructure, PropertyNames = Property.Name };
-        }
-
-        public IEnumerable<IConceptInfo> CreateNewConcepts(IEnumerable<IConceptInfo> existingConcepts)
-        {
-            return new[] { GetCreatedIndex() };
+            return new[]
+            {
+                new SqlIndexMultipleInfo
+                {
+                    DataStructure = conceptInfo.Property.DataStructure,
+                    PropertyNames = conceptInfo.Property.Name
+                }
+            };
         }
     }
 }

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DatabaseWorkarounds/SqlIndexMultiplePropertyInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DatabaseWorkarounds/SqlIndexMultiplePropertyInfo.cs
@@ -26,7 +26,7 @@ using System.Text;
 namespace Rhetos.Dsl.DefaultConcepts
 {
     [Export(typeof(IConceptInfo))]
-    public class SqlIndexMultiplePropertyInfo : IValidationConcept
+    public class SqlIndexMultiplePropertyInfo : IValidatedConcept
     {
         [ConceptKey]
         public SqlIndexMultipleInfo SqlIndex { get; set; }
@@ -34,7 +34,7 @@ namespace Rhetos.Dsl.DefaultConcepts
         [ConceptKey]
         public PropertyInfo Property { get; set; }
 
-        public void CheckSemantics(IEnumerable<IConceptInfo> concepts)
+        public void CheckSemantics(IDslModel existingConcepts)
         {
             DslUtility.CheckIfPropertyBelongsToDataStructure(Property, SqlIndex.DataStructure, this);
         }

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DatabaseWorkarounds/SqlIndexPropertyClusteredInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DatabaseWorkarounds/SqlIndexPropertyClusteredInfo.cs
@@ -17,26 +17,35 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Linq;
-using System.Text;
 
 namespace Rhetos.Dsl.DefaultConcepts
 {
     [Export(typeof(IConceptInfo))]
-    public class SqlIndexMultipleFollowingPropertyInfo : SqlIndexMultiplePropertyInfo, IValidatedConcept
+    [ConceptKeyword("Clustered")]
+    public class SqlIndexPropertyClusteredInfo : IConceptInfo
     {
-        /// <summary>
-        /// Used for property ordering when creating the index.
-        /// </summary>
-        public SqlIndexMultiplePropertyInfo PreviousIndexProperty { get; set; }
+        [ConceptKey]
+        public SqlIndexInfo SqlIndex { get; set; }
+    }
 
-        public new void CheckSemantics(IDslModel existingConcepts)
+    [Export(typeof(IConceptMacro))]
+    public class SqlIndexPropertyClusteredMacro : IConceptMacro<SqlIndexPropertyClusteredInfo>
+    {
+        public IEnumerable<IConceptInfo> CreateNewConcepts(SqlIndexPropertyClusteredInfo conceptInfo, IDslModel existingConcepts)
         {
-            base.CheckSemantics(existingConcepts);
-            DslUtility.CheckIfPropertyBelongsToDataStructure(PreviousIndexProperty.Property, SqlIndex.DataStructure, this);
+            return new[]
+            {
+                new SqlIndexClusteredInfo
+                {
+                    SqlIndex = new SqlIndexMultipleInfo
+                    {
+                        DataStructure = conceptInfo.SqlIndex.Property.DataStructure,
+                        PropertyNames = conceptInfo.SqlIndex.Property.Name
+                    }
+                }
+            };
         }
     }
 }

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DatabaseWorkarounds/UniqueClusteredInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DatabaseWorkarounds/UniqueClusteredInfo.cs
@@ -17,26 +17,35 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Linq;
-using System.Text;
 
 namespace Rhetos.Dsl.DefaultConcepts
 {
     [Export(typeof(IConceptInfo))]
-    public class SqlIndexMultipleFollowingPropertyInfo : SqlIndexMultiplePropertyInfo, IValidatedConcept
+    [ConceptKeyword("Clustered")]
+    public class UniqueClusteredInfo : IConceptInfo
     {
-        /// <summary>
-        /// Used for property ordering when creating the index.
-        /// </summary>
-        public SqlIndexMultiplePropertyInfo PreviousIndexProperty { get; set; }
+        [ConceptKey]
+        public UniqueMultiplePropertiesInfo Unique { get; set; }
+    }
 
-        public new void CheckSemantics(IDslModel existingConcepts)
+    [Export(typeof(IConceptMacro))]
+    public class UniqueClusteredMacro : IConceptMacro<UniqueClusteredInfo>
+    {
+        public IEnumerable<IConceptInfo> CreateNewConcepts(UniqueClusteredInfo conceptInfo, IDslModel existingConcepts)
         {
-            base.CheckSemantics(existingConcepts);
-            DslUtility.CheckIfPropertyBelongsToDataStructure(PreviousIndexProperty.Property, SqlIndex.DataStructure, this);
+            return new[]
+            {
+                new SqlIndexClusteredInfo
+                {
+                    SqlIndex = new SqlIndexMultipleInfo
+                    {
+                        DataStructure = conceptInfo.Unique.DataStructure,
+                        PropertyNames = conceptInfo.Unique.PropertyNames
+                    }
+                }
+            };
         }
     }
 }

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DslUtility.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DslUtility.cs
@@ -55,13 +55,8 @@ namespace Rhetos.Dsl.DefaultConcepts
         public static void CheckIfPropertyBelongsToDataStructure(PropertyInfo property, DataStructureInfo dataStructure, IConceptInfo errorContext)
         {
             if (property.DataStructure != dataStructure)
-                throw new Exception(String.Format(
-                    "Invalid use of " + errorContext.GetKeywordOrTypeName() + ": Property {0}.{1}.{2} is not in data structure {3}.{4}.",
-                    property.DataStructure.Module.Name,
-                    property.DataStructure.Name,
-                    property.Name,
-                    dataStructure.Module.Name,
-                    dataStructure.Name));
+                throw new DslSyntaxException(errorContext,
+                    $"Property {property.FullName} is not in data structure {dataStructure.FullName}.");
         }
 
         /// <summary>
@@ -133,11 +128,11 @@ namespace Rhetos.Dsl.DefaultConcepts
         /// </param>
         public static ValueOrError<PropertyInfo> GetPropertyByPath(DataStructureInfo source, string path, IDslModel existingConcepts, bool allowSystemProperties = true)
         {
-            if (path.Contains(" "))
-                return ValueOrError.CreateError("The path contains a space character.");
-
             if (string.IsNullOrEmpty(path))
                 return ValueOrError.CreateError("The path is empty.");
+
+            if (path.Contains(" "))
+                return ValueOrError.CreateError("The path contains a space character.");
 
             var propertyNames = path.Split('.');
             var referenceNames = propertyNames.Take(propertyNames.Count() - 1).ToArray();

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/Rhetos.Dsl.DefaultConcepts.csproj
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/Rhetos.Dsl.DefaultConcepts.csproj
@@ -152,7 +152,9 @@
     <Compile Include="DatabaseWorkarounds\SqlDependsOnIDInfo.cs" />
     <Compile Include="DatabaseWorkarounds\SqlIndexClusteredInfo.cs" />
     <Compile Include="DatabaseWorkarounds\SqlIndexMultipleFollowingPropertyInfo.cs" />
+    <Compile Include="DatabaseWorkarounds\SqlIndexPropertyClusteredInfo.cs" />
     <Compile Include="DatabaseWorkarounds\SqlNotNullInfo.cs" />
+    <Compile Include="DatabaseWorkarounds\UniqueClusteredInfo.cs" />
     <Compile Include="DataStructure\BeforeQueryWithParameterInfo.cs" />
     <Compile Include="DataStructure\PolymorphicSubtypeDiscriminatorInfo.cs" />
     <Compile Include="DataStructure\PolymorphicSubtypeReferenceInfo.cs" />

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/AutoCodeCachedInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/AutoCodeCachedInfo.cs
@@ -42,7 +42,11 @@ namespace Rhetos.Dsl.DefaultConcepts
 
         virtual protected IConceptInfo CreateUniqueConstraint()
         {
-            return new UniquePropertyInfo { Property = Property };
+            return new UniqueMultiplePropertiesInfo
+            {
+                DataStructure = Property.DataStructure,
+                PropertyNames = Property.Name
+            };
         }
     }
 }

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/AutoCodeForEachCachedInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/AutoCodeForEachCachedInfo.cs
@@ -33,11 +33,10 @@ namespace Rhetos.Dsl.DefaultConcepts
 
         protected override IConceptInfo CreateUniqueConstraint()
         {
-            return new UniquePropertiesInfo
+            return new UniqueMultiplePropertiesInfo
             {
                 DataStructure = Property.DataStructure,
-                Property1 = Group,
-                Property2 = Property
+                PropertyNames = $"{Group.Name} {Property.Name}"
             };
         }
 

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/AutoCodeForEachInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/AutoCodeForEachInfo.cs
@@ -32,11 +32,10 @@ namespace Rhetos.Dsl.DefaultConcepts
 
         protected override IConceptInfo CreateUniqueConstraint()
         {
-            return new UniquePropertiesInfo
+            return new UniqueMultiplePropertiesInfo
             {
                 DataStructure = Property.DataStructure,
-                Property1 = Group,
-                Property2 = Property
+                PropertyNames = $"{Group.Name} {Property.Name}"
             };
         }
 

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/AutoCodePropertyInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/AutoCodePropertyInfo.cs
@@ -48,7 +48,7 @@ namespace Rhetos.Dsl.DefaultConcepts
 
         virtual protected IConceptInfo CreateUniqueConstraint()
         {
-            return new UniquePropertyInfo { Property = Property };
+            return new UniqueMultiplePropertiesInfo { DataStructure = Property.DataStructure, PropertyNames = Property.Name };
         }
     }
 }

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/ReferenceDetailInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/ReferenceDetailInfo.cs
@@ -38,7 +38,7 @@ namespace Rhetos.Dsl.DefaultConcepts
             if (Reference.DataStructure is IWritableOrmDataStructure)
             {
                 newConcepts.Add(new ReferenceCascadeDeleteInfo { Reference = Reference });
-                newConcepts.Add(new SqlIndexInfo { Property = Reference });
+                newConcepts.Add(new SqlIndexMultipleInfo { DataStructure = Reference.DataStructure, PropertyNames = Reference.Name });
                 newConcepts.Add(new SystemRequiredInfo { Property = Reference });
             }
 

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/UniqueMultiplePropertyInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/UniqueMultiplePropertyInfo.cs
@@ -30,6 +30,7 @@ namespace Rhetos.Dsl.DefaultConcepts
     {
         [ConceptKey]
         public UniqueMultiplePropertiesInfo Unique { get; set; }
+
         [ConceptKey]
         public PropertyInfo Property { get; set; }
 

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/UniqueProperties3Info.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/UniqueProperties3Info.cs
@@ -27,7 +27,7 @@ namespace Rhetos.Dsl.DefaultConcepts
 {
     [Export(typeof(IConceptInfo))]
     [ConceptKeyword("Unique")]
-    public class UniqueProperties3Info : IValidationConcept, IMacroConcept
+    public class UniqueProperties3Info : IValidatedConcept
     {
         [ConceptKey]
         public DataStructureInfo DataStructure { get; set; }
@@ -38,16 +38,27 @@ namespace Rhetos.Dsl.DefaultConcepts
         [ConceptKey]
         public PropertyInfo Property3 { get; set; }
 
-        public IEnumerable<IConceptInfo> CreateNewConcepts(IEnumerable<IConceptInfo> existingConcepts)
-        {
-            return new[] { new UniqueMultiplePropertiesInfo { DataStructure = DataStructure, PropertyNames = Property1.Name + " " + Property2.Name + " " + Property3.Name } };
-        }
-
-        public void CheckSemantics(IEnumerable<IConceptInfo> concepts)
+        public void CheckSemantics(IDslModel existingConcepts)
         {
             DslUtility.CheckIfPropertyBelongsToDataStructure(Property1, DataStructure, this);
             DslUtility.CheckIfPropertyBelongsToDataStructure(Property2, DataStructure, this);
             DslUtility.CheckIfPropertyBelongsToDataStructure(Property3, DataStructure, this);
+        }
+    }
+
+    [Export(typeof(IConceptMacro))]
+    public class UniqueProperties3Macro : IConceptMacro<UniqueProperties3Info>
+    {
+        public IEnumerable<IConceptInfo> CreateNewConcepts(UniqueProperties3Info conceptInfo, IDslModel existingConcepts)
+        {
+            return new[]
+            {
+                new UniqueMultiplePropertiesInfo
+                {
+                    DataStructure = conceptInfo.DataStructure,
+                    PropertyNames = conceptInfo.Property1.Name + " " + conceptInfo.Property2.Name + " " + conceptInfo.Property3.Name
+                }
+            };
         }
     }
 }

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/UniquePropertiesInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/UniquePropertiesInfo.cs
@@ -27,7 +27,7 @@ namespace Rhetos.Dsl.DefaultConcepts
 {
     [Export(typeof(IConceptInfo))]
     [ConceptKeyword("Unique")]
-    public class UniquePropertiesInfo : IValidationConcept, IMacroConcept
+    public class UniquePropertiesInfo : IValidatedConcept
     {
         [ConceptKey]
         public DataStructureInfo DataStructure { get; set; }
@@ -36,15 +36,26 @@ namespace Rhetos.Dsl.DefaultConcepts
         [ConceptKey]
         public PropertyInfo Property2 { get; set; }
 
-        public IEnumerable<IConceptInfo> CreateNewConcepts(IEnumerable<IConceptInfo> existingConcepts)
-        {
-            return new[] { new UniqueMultiplePropertiesInfo { DataStructure = DataStructure, PropertyNames = Property1.Name + " " + Property2.Name } };
-        }
-
-        public void CheckSemantics(IEnumerable<IConceptInfo> concepts)
+        public void CheckSemantics(IDslModel existingConcepts)
         {
             DslUtility.CheckIfPropertyBelongsToDataStructure(Property1, DataStructure, this);
             DslUtility.CheckIfPropertyBelongsToDataStructure(Property2, DataStructure, this);
+        }
+    }
+
+    [Export(typeof(IConceptMacro))]
+    public class UniquePropertiesMacro : IConceptMacro<UniquePropertiesInfo>
+    {
+        public IEnumerable<IConceptInfo> CreateNewConcepts(UniquePropertiesInfo conceptInfo, IDslModel existingConcepts)
+        {
+            return new[]
+            {
+                new UniqueMultiplePropertiesInfo
+                {
+                    DataStructure = conceptInfo.DataStructure,
+                    PropertyNames = conceptInfo.Property1.Name + " " + conceptInfo.Property2.Name
+                }
+            };
         }
     }
 }

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/UniquePropertyInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/UniquePropertyInfo.cs
@@ -27,14 +27,25 @@ namespace Rhetos.Dsl.DefaultConcepts
 {
     [Export(typeof(IConceptInfo))]
     [ConceptKeyword("Unique")]
-    public class UniquePropertyInfo : IMacroConcept
+    public class UniquePropertyInfo : IConceptInfo
     {
         [ConceptKey]
         public PropertyInfo Property { get; set; }
+    }
 
-        public IEnumerable<IConceptInfo> CreateNewConcepts(IEnumerable<IConceptInfo> existingConcepts)
+    [Export(typeof(IConceptMacro))]
+    public class UniquePropertyMacro : IConceptMacro<UniquePropertyInfo>
+    {
+        public IEnumerable<IConceptInfo> CreateNewConcepts(UniquePropertyInfo conceptInfo, IDslModel existingConcepts)
         {
-            return new[] { new UniqueMultiplePropertiesInfo { DataStructure = Property.DataStructure, PropertyNames = Property.Name } };
+            return new[]
+            {
+                new UniqueMultiplePropertiesInfo
+                {
+                    DataStructure = conceptInfo.Property.DataStructure,
+                    PropertyNames = conceptInfo.Property.Name
+                }
+            };
         }
     }
 }

--- a/Source/Rhetos.Dsl.Interfaces/ConceptMembers.cs
+++ b/Source/Rhetos.Dsl.Interfaces/ConceptMembers.cs
@@ -57,6 +57,7 @@ namespace Rhetos.Dsl
 
             var conceptMembers = conceptInfoType
                 .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .Where(p => p.CanWrite)
                 .Select(memberInfo => new ConceptMember(memberInfo, nonParsableMembers))
                 .ToArray();
 
@@ -74,7 +75,7 @@ namespace Rhetos.Dsl
                     return a.SortOrder2 - b.SortOrder2;
                 });
 
-            if (!conceptMembers.Where(m => m.IsKey).Any())
+            if (!conceptMembers.Any(m => m.IsKey))
                 throw new FrameworkException(
                     string.Format(CultureInfo.InvariantCulture,
                         "One or more members of concept-info class must have ConceptKey attribute. Class: \"{0}\".",


### PR DESCRIPTION
This will reduce issues with "same key - different value" conflicts, such as two macro concepts generating a simple index and a unique index at the same time.