### PR TITLE
 Separating foreign key constraint generator from the ReferencePropertyInfo

### DIFF
--- a/CommonConcepts/DataMigration/2.12/2 - Separate foreign key concept.sql
+++ b/CommonConcepts/DataMigration/2.12/2 - Separate foreign key concept.sql
@@ -1,0 +1,22 @@
+/*DATAMIGRATION 654F5AA3-4DB4-4C3A-8AF7-52CA3BBC5E2C*/ -- Change the script's code only if it needs to be executed again.
+
+/*
+Updating FK constraint metadata to match the new version of ReferencePropertyConstraintDatabaseDefinition,
+in order to avoid unnecessary changes in database structure during deployment.
+*/
+
+UPDATE
+    Rhetos.AppliedConcept
+SET
+    InfoType = 'Rhetos.Dsl.DefaultConcepts.ReferencePropertyDbConstraintInfo, Rhetos.Dsl.DefaultConcepts, Version=2.12.0.0, Culture=neutral, PublicKeyToken=null',
+    ConceptInfoKey = REPLACE(ConceptInfoKey, 'PropertyInfo ', 'ReferencePropertyDbConstraintInfo '),
+    CreateQuery = REPLACE(CreateQuery, '/*ReferencePropertyInfo FK options', '/*ReferencePropertyDbConstraintInfo FK options')
+WHERE
+    ImplementationType LIKE 'Rhetos.DatabaseGenerator.DefaultConcepts.ReferencePropertyConstraintDatabaseDefinition%';
+
+DELETE d
+FROM
+    Rhetos.AppliedConceptDependsOn d
+    INNER JOIN Rhetos.AppliedConcept c ON c.ID = d.DependsOnID
+WHERE
+    c.ImplementationType LIKE 'Rhetos.DatabaseGenerator.DefaultConcepts.ReferencePropertyConstraintDatabaseDefinition%';

--- a/CommonConcepts/Plugins/Rhetos.DatabaseGenerator.DefaultConcepts/ReferenceCascadeDeleteDatabaseDefinition.cs
+++ b/CommonConcepts/Plugins/Rhetos.DatabaseGenerator.DefaultConcepts/ReferenceCascadeDeleteDatabaseDefinition.cs
@@ -29,31 +29,17 @@ using System.ComponentModel.Composition;
 namespace Rhetos.DatabaseGenerator.DefaultConcepts
 {
     [Export(typeof(IConceptDatabaseDefinition))]
-    [ExportMetadata(MefProvider.Implements, typeof(ReferenceCascadeDeleteInfo))]
+    [ExportMetadata(MefProvider.Implements, typeof(ReferenceCascadeDeleteDbInfo))]
     public class ReferenceCascadeDeleteDatabaseDefinition : IConceptDatabaseDefinitionExtension
     {
-        private readonly Lazy<bool> _legacyCascadeDeleteInDatabase;
-
-        public static readonly string LegacyCascadeDeleteInDatabaseOption = "CommonConcepts.Legacy.CascadeDeleteInDatabase";
-
-
-        public ReferenceCascadeDeleteDatabaseDefinition(IConfiguration configuration)
-        {
-            _legacyCascadeDeleteInDatabase = configuration.GetBool(LegacyCascadeDeleteInDatabaseOption, true);
-        }
-
         public void ExtendDatabaseStructure(
             IConceptInfo conceptInfo, ICodeBuilder codeBuilder, 
             out IEnumerable<Tuple<IConceptInfo, IConceptInfo>> createdDependencies)
         {
-            // Cascade delete FK in database is not needed because the server application will explicitly delete the referencing data (to ensure server-side validations and recomputations).
-            // Cascade delete in database is just a legacy feature, a convenience for development and testing.
-            // It is turned off by default because if a record is deleted by cascade delete directly in the database, then the business logic implemented in application layer will not be executed.
-            var info = (ReferenceCascadeDeleteInfo)conceptInfo;
+            var info = (ReferenceCascadeDeleteDbInfo)conceptInfo;
 
-            if (_legacyCascadeDeleteInDatabase.Value && ReferencePropertyConstraintDatabaseDefinition.IsSupported(info.Reference))
-                codeBuilder.InsertCode(Sql.Get("ReferenceCascadeDeleteDatabaseDefinition_ExtendForeignKey"),
-                    ReferencePropertyConstraintDatabaseDefinition.ForeignKeyConstraintOptions, info.Reference);
+            codeBuilder.InsertCode(Sql.Get("ReferenceCascadeDeleteDatabaseDefinition_ExtendForeignKey"),
+                ReferencePropertyConstraintDatabaseDefinition.ForeignKeyConstraintOptions, info.ReferenceDbConstraint);
 
             createdDependencies = null;
         }

--- a/CommonConcepts/Plugins/Rhetos.DatabaseGenerator.DefaultConcepts/ReferencePropertyDatabaseDefinition.cs
+++ b/CommonConcepts/Plugins/Rhetos.DatabaseGenerator.DefaultConcepts/ReferencePropertyDatabaseDefinition.cs
@@ -37,16 +37,11 @@ namespace Rhetos.DatabaseGenerator.DefaultConcepts
     [ConceptImplementationVersion(2, 0)]
     public class ReferencePropertyDatabaseDefinition : IConceptDatabaseDefinition
     {
-        ConceptMetadata _conceptMetadata;
+        private readonly ConceptMetadata _conceptMetadata;
 
         public ReferencePropertyDatabaseDefinition(ConceptMetadata conceptMetadata)
         {
             _conceptMetadata = conceptMetadata;
-        }
-
-        public static bool IsSupported(ReferencePropertyInfo info)
-        {
-            return info.DataStructure is EntityInfo;
         }
 
         public string CreateDatabaseStructure(IConceptInfo conceptInfo)
@@ -54,7 +49,7 @@ namespace Rhetos.DatabaseGenerator.DefaultConcepts
             var info = (ReferencePropertyInfo)conceptInfo;
 
             PropertyDatabaseDefinition.RegisterColumnMetadata(_conceptMetadata, info, info.GetColumnName(), Sql.Get("ReferencePropertyDatabaseDefinition_DataType"));
-            if (IsSupported(info))
+            if (info.DataStructure is EntityInfo)
                 return PropertyDatabaseDefinition.AddColumn(_conceptMetadata, info);
 
             return "";
@@ -63,7 +58,7 @@ namespace Rhetos.DatabaseGenerator.DefaultConcepts
         public string RemoveDatabaseStructure(IConceptInfo conceptInfo)
         {
             var info = (ReferencePropertyInfo)conceptInfo;
-            if (IsSupported(info))
+            if (info.DataStructure is EntityInfo)
                 return PropertyDatabaseDefinition.RemoveColumn(info, info.GetColumnName());
             return "";
         }

--- a/CommonConcepts/Plugins/Rhetos.DatabaseGenerator.DefaultConcepts/Rhetos.DatabaseGenerator.DefaultConcepts.csproj
+++ b/CommonConcepts/Plugins/Rhetos.DatabaseGenerator.DefaultConcepts/Rhetos.DatabaseGenerator.DefaultConcepts.csproj
@@ -160,7 +160,6 @@
     <Compile Include="SqlQueryableDatabaseDefinition.cs" />
     <Compile Include="SqlDependsOnPropertyDatabaseDefinition.cs" />
     <Compile Include="EntityLoggingDefinition.cs" />
-    <Compile Include="Extensions.cs" />
     <Compile Include="PropertyLoggingDefinition.cs" />
     <Compile Include="ReferencePropertyConstraintDatabaseDefinition.cs" />
     <Compile Include="SqlDefaultPropertyDatabaseDefinition.cs" />

--- a/CommonConcepts/Plugins/Rhetos.DatabaseGenerator.DefaultConcepts/UniqueReferenceCascadeDeleteDatabaseDefinition.cs
+++ b/CommonConcepts/Plugins/Rhetos.DatabaseGenerator.DefaultConcepts/UniqueReferenceCascadeDeleteDatabaseDefinition.cs
@@ -36,7 +36,7 @@ namespace Rhetos.DatabaseGenerator.DefaultConcepts
 
         public UniqueReferenceCascadeDeleteDatabaseDefinition(IConfiguration configuration)
         {
-            _legacyCascadeDeleteInDatabase = configuration.GetBool(ReferenceCascadeDeleteDatabaseDefinition.LegacyCascadeDeleteInDatabaseOption, true);
+            _legacyCascadeDeleteInDatabase = configuration.GetBool(ReferenceCascadeDeleteMacro.LegacyCascadeDeleteInDatabaseOption, true);
         }
 
         public void ExtendDatabaseStructure(

--- a/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/DataStructure/Properties/ReferencePropertyCodeGenerator.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/DataStructure/Properties/ReferencePropertyCodeGenerator.cs
@@ -59,7 +59,7 @@ namespace Rhetos.Dom.DefaultConcepts
                         info.DataStructure.Module.Name, info.DataStructure.Name, info.Name),
                     DomInitializationCodeGenerator.EntityFrameworkOnModelCreatingTag);
 
-            if (ReferencePropertyConstraintDatabaseDefinition.IsSupported(info)
+            if (ReferencePropertyDbConstraintInfo.IsSupported(info)
                 && info.DataStructure is IOrmDataStructure
                 && info.Referenced is IOrmDataStructure)
             {

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DataStructure/Properties/ReferencePropertyDbConstraintInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DataStructure/Properties/ReferencePropertyDbConstraintInfo.cs
@@ -1,0 +1,55 @@
+﻿/*
+    Copyright (C) 2014 Omega software d.o.o.
+
+    This file is part of Rhetos.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using Rhetos.Utilities;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+
+namespace Rhetos.Dsl.DefaultConcepts
+{
+    /// <summary>
+    /// An internal concept for generating FK constraint in database.
+    /// This concept is separate from the ReferencePropertyInfo concept to allow changes in FK constraint
+    /// without making unnecessary database modifications (refresh) in features that depend on the ReferencePropertyInfo.
+    /// </summary>
+    [Export(typeof(IConceptInfo))]
+    public class ReferencePropertyDbConstraintInfo: IConceptInfo
+    {
+        [ConceptKey]
+        public ReferencePropertyInfo Reference { get; set; }
+
+        public static bool IsSupported(ReferencePropertyInfo reference)
+        {
+            return reference.DataStructure is EntityInfo
+                && ForeignKeyUtility.GetSchemaTableForForeignKey(reference.Referenced) != null;
+        }
+    }
+
+    [Export(typeof(IConceptMacro))]
+    public class ReferencePropertyDbConstraintMacro : IConceptMacro<InitializationConcept>
+    {
+        public IEnumerable<IConceptInfo> CreateNewConcepts(InitializationConcept conceptInfo, IDslModel existingConcepts)
+        {
+            return existingConcepts.FindByType<ReferencePropertyInfo>()
+                .Where(ReferencePropertyDbConstraintInfo.IsSupported)
+                .Select(rp => new ReferencePropertyDbConstraintInfo { Reference = rp });
+        }
+    }
+}

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DatabaseWorkarounds/ForeignKeyUtility.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DatabaseWorkarounds/ForeignKeyUtility.cs
@@ -22,7 +22,7 @@ using Rhetos.Dsl.DefaultConcepts;
 using Rhetos.Utilities;
 using System.Collections.Generic;
 
-namespace Rhetos.DatabaseGenerator.DefaultConcepts
+namespace Rhetos.Dsl.DefaultConcepts
 {
     public static class ForeignKeyUtility
     {

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/Rhetos.Dsl.DefaultConcepts.csproj
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/Rhetos.Dsl.DefaultConcepts.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Computations\LockItemsLockPropertyInfo.cs" />
     <Compile Include="Computations\PersistedKeyPropertiesInfo.cs" />
     <Compile Include="Computations\KeyPropertyComputedFromInfo.cs" />
+    <Compile Include="DatabaseWorkarounds\ForeignKeyUtility.cs" />
     <Compile Include="DatabaseWorkarounds\SqlDependsOnIDInfo.cs" />
     <Compile Include="DatabaseWorkarounds\SqlIndexClusteredInfo.cs" />
     <Compile Include="DatabaseWorkarounds\SqlIndexMultipleFollowingPropertyInfo.cs" />
@@ -156,6 +157,7 @@
     <Compile Include="DataStructure\BeforeQueryWithParameterInfo.cs" />
     <Compile Include="DataStructure\PolymorphicSubtypeDiscriminatorInfo.cs" />
     <Compile Include="DataStructure\PolymorphicSubtypeReferenceInfo.cs" />
+    <Compile Include="DataStructure\Properties\ReferencePropertyDbConstraintInfo.cs" />
     <Compile Include="DataStructure\RepositoryMemberInfo.cs" />
     <Compile Include="DataStructure\SamePropertyValueInfo.cs" />
     <Compile Include="DataStructure\UniqueReferenceInfo.cs" />
@@ -301,6 +303,7 @@
     <Compile Include="SimpleBusinessLogic\CreatedByInfo.cs" />
     <Compile Include="SimpleBusinessLogic\DefaultValueInfo.cs" />
     <Compile Include="SimpleBusinessLogic\LogReaderAdditionalSourceInfo.cs" />
+    <Compile Include="SimpleBusinessLogic\ReferenceCascadeDeleteDbInfo.cs" />
     <Compile Include="SimpleBusinessLogic\ReferenceCascadeDeletePolymorphicInfo.cs" />
     <Compile Include="SimpleBusinessLogic\UniqueReferenceCascadeDeletePolymorphicInfo.cs" />
     <Compile Include="SimpleBusinessLogic\UniqueReferenceCascadeDeleteInfo.cs" />

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/ReferenceCascadeDeleteDbInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/ReferenceCascadeDeleteDbInfo.cs
@@ -1,0 +1,35 @@
+﻿/*
+    Copyright (C) 2014 Omega software d.o.o.
+
+    This file is part of Rhetos.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using System.ComponentModel.Composition;
+
+namespace Rhetos.Dsl.DefaultConcepts
+{
+    /// <summary>
+    /// An internal concept for generating cascade delete in database.
+    /// It should be rarely used because deleting records directly in database
+    /// circumvents any business logic implemented in the application related to those records.
+    /// </summary>
+    [Export(typeof(IConceptInfo))]
+    public class ReferenceCascadeDeleteDbInfo : IConceptInfo
+    {
+        [ConceptKey]
+        public ReferencePropertyDbConstraintInfo ReferenceDbConstraint { get; set; }
+    }
+}

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/ReferenceCascadeDeleteInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/ReferenceCascadeDeleteInfo.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using System.Text;
 using Rhetos.Dsl;
 using System.ComponentModel.Composition;
+using Rhetos.Utilities;
 
 namespace Rhetos.Dsl.DefaultConcepts
 {
@@ -30,8 +31,8 @@ namespace Rhetos.Dsl.DefaultConcepts
     /// Automatically deletes detail records when a master record is deleted.
     /// </summary>
     /// <remarks>
-    /// This feature does not create "on delete cascade" in database
-    /// (since Rhetos v2.11, unless CommonConcepts.Legacy.CascadeDeleteInDatabase is enabled).
+    /// This feature does not create "on delete cascade" in database unless CommonConcepts.Legacy.CascadeDeleteInDatabase
+    /// is enabled (since Rhetos v2.11).
     /// It is implemented in the application layer, because a database implementation would not execute
     /// any business logic that is implemented on the child entity.
     /// </remarks> 
@@ -46,19 +47,39 @@ namespace Rhetos.Dsl.DefaultConcepts
     [Export(typeof(IConceptMacro))]
     public class ReferenceCascadeDeleteMacro : IConceptMacro<ReferenceCascadeDeleteInfo>
     {
+        public static readonly string LegacyCascadeDeleteInDatabaseOption = "CommonConcepts.Legacy.CascadeDeleteInDatabase";
+
+        private readonly IConfiguration _configuration;
+
+        public ReferenceCascadeDeleteMacro(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
         public IEnumerable<IConceptInfo> CreateNewConcepts(ReferenceCascadeDeleteInfo conceptInfo, IDslModel existingConcepts)
         {
+            var newConcepts = new List<IConceptInfo>();
+
             if (conceptInfo.Reference.Referenced is PolymorphicInfo && conceptInfo.Reference.DataStructure is IWritableOrmDataStructure)
-                return new[]
+                newConcepts.Add(new ReferenceCascadeDeletePolymorphicInfo
                 {
-                    new ReferenceCascadeDeletePolymorphicInfo
+                    Reference = conceptInfo.Reference,
+                    Parent = ((PolymorphicInfo)conceptInfo.Reference.Referenced).GetMaterializedEntity()
+                });
+
+            // Cascade delete FK in database is not needed because the server application will explicitly delete the referencing data (to ensure server-side validations and recomputations).
+            // Cascade delete in database is just a legacy feature, a convenience for development and testing.
+            // It is turned off by default because if a record is deleted by cascade delete directly in the database, then the business logic implemented in application layer will not be executed.
+            if (_configuration.GetBool(LegacyCascadeDeleteInDatabaseOption, true).Value)
+            {
+                var dbConstraint = (ReferencePropertyDbConstraintInfo)existingConcepts.FindByKey($"ReferencePropertyDbConstraintInfo {conceptInfo.Reference}");
+                if (dbConstraint != null)
+                    newConcepts.Add(new ReferenceCascadeDeleteDbInfo
                     {
-                        Reference = conceptInfo.Reference,
-                        Parent = ((PolymorphicInfo)conceptInfo.Reference.Referenced).GetMaterializedEntity()
-                    }
-                };
-            else
-                return null;
+                        ReferenceDbConstraint = dbConstraint
+                    });
+            }
+
+            return newConcepts;
         }
     }
 }

--- a/Source/Rhetos.Utilities.Test/CsUtilityTest.cs
+++ b/Source/Rhetos.Utilities.Test/CsUtilityTest.cs
@@ -217,5 +217,56 @@ namespace Rhetos.Utilities.Test
             foreach (var test in tests)
                 Assert.AreEqual(test.Item2, CsUtility.FirstLine(test.Item1), "Test: " + test.Item1);
         }
+
+        [TestMethod]
+        public void ReportSegment()
+        {
+            var tests = new ListOfTuples<string, int, int, string>
+            {
+                { "", -100, 3, "" },
+                { "", -1, 3, "" },
+                { "", 0, 3, "" },
+                { "", 1, 3, "" },
+                { "", 100, 3, "" },
+
+                { "abc", -1000, 100, "abc" },
+                { "abc", -10, 100, "abc" },
+                { "abc", 0, 100, "abc" },
+                { "abc", 10, 100, "abc" },
+                { "abc", 1000, 100, "abc" },
+
+                { "abcde", 0, 1, "a..." },
+                { "abcde", 1, 1, "...b..." },
+                { "abcde", 5, 1, "...e" },
+
+                { "abcde", -10, 3, "abc..." },
+                { "abcde", -1, 3, "abc..." },
+                { "abcde", 0, 3, "abc..." },
+                { "abcde", 1, 3, "abc..." },
+                { "abcde", 2, 3, "...bcd..." },
+                { "abcde", 3, 3, "...cde" },
+                { "abcde", 4, 3, "...cde" },
+                { "abcde", 5, 3, "...cde" },
+                { "abcde", 10, 3, "...cde" },
+
+                { "abcde", -10, 2, "ab..." },
+                { "abcde", -1, 2, "ab..." },
+                { "abcde", 0, 2, "ab..." },
+                { "abcde", 1, 2, "ab..." },
+                { "abcde", 2, 2, "...bc..." },
+                { "abcde", 3, 2, "...cd..." },
+                { "abcde", 4, 2, "...de" },
+                { "abcde", 5, 2, "...de" },
+                { "abcde", 10, 2, "...de" },
+
+                { "\r\n\t", 0, 1, @"\r..." },
+                { "\r\n\t", 1, 1, @"...\n..." },
+                { "\r\n\t", 2, 1, @"...\t" },
+                { "\r\n\t\\", 2, 10, @"\r\n\t\\" },
+            };
+
+            foreach (var test in tests)
+                Assert.AreEqual(test.Item4, CsUtility.ReportSegment(test.Item1, test.Item2, test.Item3), $"Test: {test.Item1} {test.Item2} {test.Item3}");
+        }
     }
 }

--- a/Source/Rhetos.Utilities/CsUtility.cs
+++ b/Source/Rhetos.Utilities/CsUtility.cs
@@ -347,5 +347,30 @@ namespace Rhetos.Utilities
             else
                 return text;
         }
+
+        public static string ReportSegment(string query, int showPosition, int maxLength)
+        {
+            int start = showPosition - maxLength / 2;
+            int end = showPosition + (maxLength + 1) / 2;
+            if (start < 0)
+            {
+                end += -start;
+                start = 0;
+            }
+            if (end > query.Length)
+            {
+                start -= end - query.Length;
+                end = query.Length;
+            }
+            if (start < 0)
+                start = 0;
+
+            string prefix = start > 0 ? "..." : "";
+            string suffix = end < query.Length ? "..." : "";
+
+            return prefix
+                + query.Substring(start, end - start).Replace(@"\", @"\\").Replace("\r", @"\r").Replace("\n", @"\n").Replace("\t", @"\t")
+                + suffix;
+        }
     }
 }


### PR DESCRIPTION
This will reduce unnecessary changes of dependent objects in database.
For example, if a view depends on a reference property (a table column),
it should not depend on changes in the foreign key constraint on that column.