### PR TITLE
Bugfix: Backup data-migration column is dropped when converting table to view

### DIFF
--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DataStructure/SamePropertyValue2Info.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DataStructure/SamePropertyValue2Info.cs
@@ -33,6 +33,7 @@ namespace Rhetos.Dsl.DefaultConcepts
     /// </summary>
     [Export(typeof(IConceptInfo))]
     [ConceptKeyword("SamePropertyValue")]
+    [Obsolete("Use simpler SamePropertyValue syntax with a path to the base property.")]
     public class SamePropertyValue2Info : SamePropertyValueInfo, IValidatedConcept, IAlternativeInitializationConcept
     {
         /// <summary>Object model property name on the inherited data structure that references the base data structure class.</summary>

--- a/Source/Rhetos.Deployment/DatabaseCleaner.cs
+++ b/Source/Rhetos.Deployment/DatabaseCleaner.cs
@@ -130,7 +130,16 @@ namespace Rhetos.Deployment
             var allColumns = new List<ColumnInfo>();
 
             _sqlExecuter.ExecuteReader(
-                "SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS",
+                @"SELECT
+                    c.TABLE_SCHEMA, c.TABLE_NAME, c.COLUMN_NAME
+                FROM
+                    INFORMATION_SCHEMA.COLUMNS c
+                    INNER JOIN INFORMATION_SCHEMA.TABLES t
+                        ON t.TABLE_CATALOG = c.TABLE_CATALOG
+                        AND t.TABLE_SCHEMA = c.TABLE_SCHEMA
+                        AND t.TABLE_NAME = c.TABLE_NAME
+                WHERE
+                    t.TABLE_TYPE = 'BASE TABLE'",
                 reader =>
                 {
                     allColumns.Add(new ColumnInfo(reader.GetString(0), reader.GetString(1), reader.GetString(2)));


### PR DESCRIPTION
It is not directly related to this fix, but I have also marked obsolete the old SamePropertyValue concept syntax.