### PR TITLE
AutoInheritRowPermissions now safely ignores self-references when inheriting row permissions

### DIFF
--- a/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/RowPermissionsTest.cs
+++ b/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/RowPermissionsTest.cs
@@ -457,20 +457,18 @@ namespace CommonConcepts.Test
                 var testData = new[] { "a1", "a2", "b1", "b2" }.Select(name => new TestRowPermissions.AutoFilter { Name = name });
                 gr.Save(testData, null, gr.Load());
 
-                int lastFilterCount = logFilterQuery.Count();
-
                 {
                     var readCommand = new ReadCommandInfo
                     {
                         DataSource = "TestRowPermissions.AutoFilter",
                         ReadRecords = true
                     };
+                    int lastFilterCount = logFilterQuery.Count();
                     var readResult = (TestRowPermissions.AutoFilter[])ExecuteReadCommand(readCommand, container).Records;
                     Assert.AreEqual("a1, a2", TestUtility.DumpSorted(readResult, item => item.Name));
 
                     Assert.AreEqual(1, logFilterQuery.Count() - lastFilterCount,
                         "Row permission filter should be automatically applied on reading, no need to be applied again on result permission validation.");
-                    lastFilterCount = logFilterQuery.Count();
                 }
 
                 {
@@ -480,12 +478,12 @@ namespace CommonConcepts.Test
                         ReadRecords = true,
                         Filters = new FilterCriteria[] { new FilterCriteria("Name", "contains", "2") }
                     };
+                    int lastFilterCount = logFilterQuery.Count();
                     var readResult = (TestRowPermissions.AutoFilter[])ExecuteReadCommand(readCommand, container).Records;
                     Assert.AreEqual("a2", TestUtility.DumpSorted(readResult, item => item.Name));
 
                     Assert.AreEqual(1, logFilterQuery.Count() - lastFilterCount,
                         "Row permission filter should be automatically applied on reading, no need to be use it again for result permission validation.");
-                    lastFilterCount = logFilterQuery.Count();
                 }
 
                 {
@@ -495,12 +493,12 @@ namespace CommonConcepts.Test
                         ReadRecords = true,
                         Filters = new FilterCriteria[] { new FilterCriteria("Name", "contains", "2"), new FilterCriteria(typeof(Common.RowPermissionsReadItems)) }
                     };
+                    int lastFilterCount = logFilterQuery.Count();
                     var readResult = (TestRowPermissions.AutoFilter[])ExecuteReadCommand(readCommand, container).Records;
                     Assert.AreEqual("a2", TestUtility.DumpSorted(readResult, item => item.Name));
 
                     Assert.AreEqual(1, logFilterQuery.Count() - lastFilterCount,
                         "Row permission filter should be automatically applied on reading, no need to be use it again for result permission validation.");
-                    lastFilterCount = logFilterQuery.Count();
                 }
 
                 {
@@ -510,12 +508,12 @@ namespace CommonConcepts.Test
                         ReadRecords = true,
                         Filters = new FilterCriteria[] { new FilterCriteria(typeof(Common.RowPermissionsReadItems)), new FilterCriteria("Name", "contains", "2") }
                     };
+                    int lastFilterCount = logFilterQuery.Count();
                     var readResult = (TestRowPermissions.AutoFilter[])ExecuteReadCommand(readCommand, container).Records;
                     Assert.AreEqual("a2", TestUtility.DumpSorted(readResult, item => item.Name));
 
                     Assert.AreEqual(2, logFilterQuery.Count() - lastFilterCount,
                         "Row permission filter is not the last filter applied on reading. It will be use again for result permission validation to make sure other filters did not expand the result set.");
-                    lastFilterCount = logFilterQuery.Count();
                 }
             }
         }
@@ -552,7 +550,6 @@ namespace CommonConcepts.Test
             using (var container = new RhetosTestContainer())
             {
                 container.AddIgnoreClaims();
-                var processingEngine = container.Resolve<IProcessingEngine>();
                 var repository = container.Resolve<Common.DomRepository>();
                 var readCommand = container.Resolve<IPluginsContainer<ICommandImplementation>>().GetPlugins().OfType<ReadCommand>().Single();
                 Guid testRun = Guid.NewGuid();
@@ -641,13 +638,13 @@ namespace CommonConcepts.Test
             TestWrite(null, items.ToArray(), null, null, null);
 
             var initial = items.ToArray();
-            var id25 = items.Where(a => a.value == 25).Single().ID;
+            var id25 = items.Single(a => a.value == 25).ID;
             items.ForEach(a => a.value = a.value * 2);
 
             // update items
             {
                 var result = TestWrite(initial, null, items.ToArray(), null, null);
-                Assert.AreEqual(50, result.Where(a => a.ID == id25).Single().value);
+                Assert.AreEqual(50, result.Single(a => a.ID == id25).value);
             }
 
             // delete all
@@ -987,7 +984,6 @@ namespace CommonConcepts.Test
         {
             using (var container = new RhetosTestContainer())
             {
-                var context = container.Resolve<Common.ExecutionContext>();
                 var repository = container.Resolve<Common.DomRepository>();
 
                 Guid groupID = Guid.NewGuid();

--- a/CommonConcepts/CommonConceptsTest/DslScripts/RowPermissions.rhe
+++ b/CommonConcepts/CommonConceptsTest/DslScripts/RowPermissions.rhe
@@ -183,34 +183,34 @@ Module TestRowPermissions
     
     //===============================================================
     
-    Entity Parent
+    Entity Level1
     {
         Integer value;
         RowPermissionsRead '(source, repo, context) => item => item.value > 100 && item.value < 200';
         RowPermissionsWrite '(source, repo, context) => item => item.value > 50 && item.value < 150';
     }
     
-    Entity Child
+    Entity Level2
     {
         Integer value;
-        Reference MyParent TestRowPermissions.Parent;
+        Reference MyParent TestRowPermissions.Level1;
         RowPermissions
         {
-            InheritFrom TestRowPermissions.Child.MyParent;
+            InheritFrom TestRowPermissions.Level2.MyParent;
             DenyRead Denied 'context => item => new List<int?>() { 1, 2, 3 }.Contains(item.value)';
         }
     }
     
-    Entity Baby
+    Entity Level3
     {
-        Reference MyParent TestRowPermissions.Child;
+        Reference MyParent TestRowPermissions.Level2;
         RowPermissions
         {
-            InheritFrom TestRowPermissions.Baby.MyParent;
+            InheritFrom TestRowPermissions.Level3.MyParent;
         }
     }
 
-    Browse ParentBrowse TestRowPermissions.Parent
+    Browse Level1Browse TestRowPermissions.Level1
     {
         Take Value2 value;
         RowPermissions { InheritFromBase; }
@@ -400,5 +400,28 @@ Module TestRowPermissions
         Extends TestRowPermissions.OptimizeBase;
         ShortString NameE;
         RowPermissions { InheritFromBase; }
+    }
+}
+
+Module TestRowPermissions5
+{
+    AutoInheritRowPermissions;
+
+    Entity Employee
+    {
+        ShortString Name;
+        Reference Supervisor TestRowPermissions5.Employee { Detail; }
+
+        RowPermissions
+        {
+            Allow Access1 'context => item => item.Name == "Jane" || item.Supervisor.Name == "Jane"';
+            Allow Access2 'context => item => item.Name == "John" || item.Supervisor.Name == "John"';
+        }
+    }
+
+    Browse EmployeeBrowse TestRowPermissions5.Employee
+    {
+        Take 'Name';
+        Take 'Supervisor.Name';
     }
 }

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/RowPermissions/AutoInheritRowPermissionsInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/RowPermissions/AutoInheritRowPermissionsInfo.cs
@@ -103,6 +103,7 @@ namespace Rhetos.Dsl.DefaultConcepts
 
                 newInheritences.AddRange(newDataStructuresWithRowPermissions
                     .SelectMany(ds => autoInheritDetailsByMaster.Get(ds))
+                    .Where(detail => detail.Reference.DataStructure != detail.Reference.Referenced)
                     .SelectMany(detail =>
                     {
                         var rpFilters = new RowPermissionsPluginableFiltersInfo { DataStructure = detail.Reference.DataStructure };
@@ -119,7 +120,7 @@ namespace Rhetos.Dsl.DefaultConcepts
 
                 foreach (var dataStructure in newDataStructuresWithRowPermissions)
                     allDataStructuresWithRowPermissions.Add(dataStructure);
-            };
+            }
 
             return newConcepts;
         }

--- a/Source/DeployPackages/App.config
+++ b/Source/DeployPackages/App.config
@@ -28,7 +28,9 @@
         <target name="PerformanceLogBase" xsi:type="File" fileName="${basedir}\..\Logs\DeployPackagesPerformance.log" encoding="utf-8" deleteOldFileOnStartup="true"/>
       </target>
       <target name="KeywordsLog" xsi:type="File" fileName="${basedir}\..\Logs\DeployPackagesKeywords.log" encoding="utf-8" deleteOldFileOnStartup="true"/>
-      <target name="DslModelConceptsLog" xsi:type="File" fileName="${basedir}\..\Logs\DeployPackagesDslModel.log" layout="${message}" encoding="utf-8" deleteOldFileOnStartup="true"/>
+      <target name="DslModelConceptsLog" xsi:type="AsyncWrapper" overflowAction="Block">
+        <target name="DslModelConceptsLogBase" xsi:type="File" fileName="${basedir}\..\Logs\DeployPackagesDslModel.log" layout="${message}" encoding="utf-8" deleteOldFileOnStartup="true"/>
+      </target>
       <target name="MacroEvaluatorsOrderLog" xsi:type="File" fileName="${basedir}\..\Logs\DeployPackagesMacroEvaluatorsOrder.log" encoding="utf-8" deleteOldFileOnStartup="true"/>
     </targets>
     <rules>


### PR DESCRIPTION
Inheriting through self-reference would result with recursive row permissions definition which cannot be simply implemented or converted to SQL query. It make sense to ignore this situations so that developers don't need to remove AutoInheritRowPermissions from the module.
This closes #35

This PR also includes minor refactoring of unit tests, and better logger for DslModelConceptsLog (async logging).