### PR TITLE
Sorting DSL model by key (for testing/debugging)

### DIFF
--- a/CommonConcepts/Plugins/Rhetos.CommonConcepts.Test/Mocks/DslModelMock.cs
+++ b/CommonConcepts/Plugins/Rhetos.CommonConcepts.Test/Mocks/DslModelMock.cs
@@ -31,12 +31,7 @@ namespace Rhetos.CommonConcepts.Test.Mocks
 
         public IConceptInfo FindByKey(string conceptKey)
         {
-            return this.Where(c => c.GetKey() == conceptKey).SingleOrDefault();
-        }
-
-        public IEnumerable<IConceptInfo> FindByType(Type conceptType)
-        {
-            return this.Where(c => conceptType.IsAssignableFrom(c.GetType()));
+            return this.SingleOrDefault(c => c.GetKey() == conceptKey);
         }
 
         public T GetIndex<T>() where T : IDslModelIndex

--- a/Source/Rhetos.DatabaseGenerator.Test/DatabaseGeneratorTest.cs
+++ b/Source/Rhetos.DatabaseGenerator.Test/DatabaseGeneratorTest.cs
@@ -17,21 +17,17 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-using Rhetos.Utilities;
-using Rhetos.Compiler;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using Rhetos.Dsl;
-using System.Linq;
-using Rhetos.Extensibility;
-using Rhetos.Logging;
-using Rhetos.TestCommon;
-using Rhetos.DatabaseGenerator;
-using System.Text;
 using Autofac.Features.Indexed;
 using Autofac.Features.Metadata;
-using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Rhetos.Compiler;
+using Rhetos.Dsl;
+using Rhetos.Extensibility;
+using Rhetos.TestCommon;
+using Rhetos.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Rhetos.DatabaseGenerator.Test
 {
@@ -612,11 +608,9 @@ namespace Rhetos.DatabaseGenerator.Test
 
         class MockDslModel : IDslModel
         {
-            private readonly IEnumerable<IConceptInfo> _conceptInfos;
-            public MockDslModel(IEnumerable<IConceptInfo> conceptInfos) { _conceptInfos = conceptInfos; }
-            public IEnumerable<IConceptInfo> Concepts { get { return _conceptInfos; } }
+            public MockDslModel(IEnumerable<IConceptInfo> conceptInfos) { Concepts = conceptInfos; }
+            public IEnumerable<IConceptInfo> Concepts { get; private set; }
             public IConceptInfo FindByKey(string conceptKey) { throw new NotImplementedException(); }
-            public IEnumerable<IConceptInfo> FindByType(Type conceptType) { throw new NotImplementedException(); }
             public T GetIndex<T>() where T : IDslModelIndex
             {
                 throw new NotImplementedException();

--- a/Source/Rhetos.Dsl.Interfaces/DslModelIndexByType.cs
+++ b/Source/Rhetos.Dsl.Interfaces/DslModelIndexByType.cs
@@ -17,13 +17,10 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using Rhetos.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Diagnostics.Contracts;
-using System.ComponentModel.Composition;
-using Rhetos.Utilities;
 
 namespace Rhetos.Dsl
 {

--- a/Source/Rhetos.Dsl.Test/DslContainerTest.cs
+++ b/Source/Rhetos.Dsl.Test/DslContainerTest.cs
@@ -33,7 +33,7 @@ namespace Rhetos.Dsl.Test
         class DslContainerAccessor : DslContainer
         {
             public DslContainerAccessor()
-                : base(new ConsoleLogProvider(), new MockPluginsContainer<IDslModelIndex>(new DslModelIndexByType()))
+                : base(new ConsoleLogProvider(), new MockPluginsContainer<IDslModelIndex>(new DslModelIndexByType()), new MockConfiguration())
             {
             }
         }

--- a/Source/Rhetos.Dsl.Test/DslModelTest.cs
+++ b/Source/Rhetos.Dsl.Test/DslModelTest.cs
@@ -127,8 +127,16 @@ namespace Rhetos.Dsl.Test
 
         static IDslModel NewDslModel(IDslParser parser, IEnumerable<IConceptInfo> conceptPrototypes)
         {
-            var dslContainter = new DslContainer(new ConsoleLogProvider(), new MockPluginsContainer<IDslModelIndex>(new DslModelIndexByType()));
-            var dslModel = new DslModel(parser, new ConsoleLogProvider(), dslContainter, new StubMacroIndex(), new IConceptMacro[] { }, conceptPrototypes, new StubMacroOrderRepository(), new StubDslModelFile());
+            var dslContainter = new DslContainer(new ConsoleLogProvider(), new MockPluginsContainer<IDslModelIndex>(new DslModelIndexByType()), new MockConfiguration());
+            var dslModel = new DslModel(
+                parser,
+                new ConsoleLogProvider(),
+                dslContainter,
+                new StubMacroIndex(),
+                new IConceptMacro[] { },
+                conceptPrototypes,
+                new StubMacroOrderRepository(),
+                new StubDslModelFile());
             return dslModel;
         }
 

--- a/Source/Rhetos.Dsl/DslModelFile.cs
+++ b/Source/Rhetos.Dsl/DslModelFile.cs
@@ -20,7 +20,6 @@
 using Newtonsoft.Json;
 using Rhetos.Logging;
 using Rhetos.Utilities;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -32,10 +31,7 @@ namespace Rhetos.Dsl
     public class DslModelFile : IDslModel, IDslModelFile
     {
         private readonly ILogger _performanceLogger;
-        private readonly ILogger _logger;
-        private readonly ILogger _dslModelConceptsLogger;
         private readonly DslContainer _dslContainer;
-        private readonly ISqlExecuter _sqlExecuter;
 
         public DslModelFile(
             ILogProvider logProvider,
@@ -43,10 +39,7 @@ namespace Rhetos.Dsl
             ISqlExecuter sqlExecuter)
         {
             _performanceLogger = logProvider.GetLogger("Performance");
-            _logger = logProvider.GetLogger(GetType().Name);
-            _dslModelConceptsLogger = logProvider.GetLogger("DslModelConcepts");
             _dslContainer = dslContainer;
-            _sqlExecuter = sqlExecuter;
         }
 
         #region IDslModel implementation
@@ -66,13 +59,6 @@ namespace Rhetos.Dsl
             if (!_initialized)
                 Initialize();
             return _dslContainer.FindByKey(conceptKey);
-        }
-
-        public IEnumerable<IConceptInfo> FindByType(Type conceptType)
-        {
-            if (!_initialized)
-                Initialize();
-            return _dslContainer.FindByType(conceptType);
         }
 
         public T GetIndex<T>() where T : IDslModelIndex


### PR DESCRIPTION
Sorting DSL model by key, after macro evaluation, to make it more stable and less dependent on the evaluation order. This will reduce unnecessary rebuilds of ServerDom and database object.

Sorting is enabled by setting "CommonConcepts.Debug.SortConceptsByKey" to true. It is not enabled by default, because it might result with unnecessary rebuilding of some database objects in the existing application. After implementing DSL concepts debug information, we might use the position in source for this sort to match the original order of the parsed concepts, and then enable this feature by default.