### PR TITLE
Internal improvements for easier testing and minor bugfixes

### DIFF
--- a/Clean.bat
+++ b/Clean.bat
@@ -13,6 +13,11 @@ REM Delete packages' bineries and their copy in Rhetos folder:
 @DEL /F/S/Q "Source\Rhetos\GeneratedFilesCache"
 @DEL /F/S/Q "Source\Rhetos\PackagesCache"
 @DEL /F/S/Q "Source\Rhetos\Resources"
+@RD /S/Q "Source\Rhetos\DataMigration"
+@RD /S/Q "Source\Rhetos\DslScripts"
+@RD /S/Q "Source\Rhetos\GeneratedFilesCache"
+@RD /S/Q "Source\Rhetos\PackagesCache"
+@RD /S/Q "Source\Rhetos\Resources"
 
 REM Delete build logs:
 @DEL *.log

--- a/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/AuditablePropertiesTest.cs
+++ b/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/AuditablePropertiesTest.cs
@@ -130,7 +130,7 @@ namespace CommonConcepts.Test
                     Assert.IsNotNull(generatedModificationTime, testInfo + " Insert: Generated ModificationTime is null.");
 
                     var expectedTime = ReadExpectedResult(insertData, start).Value;
-                    AssertJustAfter(expectedTime, generatedModificationTime, "After insert");
+                    AssertJustAfter(expectedTime, generatedModificationTime, testInfo + " After insert");
                 }
 
                 if (string.IsNullOrEmpty(updateData))
@@ -144,7 +144,7 @@ namespace CommonConcepts.Test
                     Assert.IsNotNull(generatedModificationTime, testInfo + " Update: Generated ModificationTime is null.");
 
                     var expectedTime = ReadExpectedResult(updateData, start).Value;
-                    AssertJustAfter(expectedTime, generatedModificationTime, "After update");
+                    AssertJustAfter(expectedTime, generatedModificationTime, testInfo + " After update");
                 }
             }
         }

--- a/CommonConcepts/CommonConceptsTest/DslScripts/SimpleBusinessLogic.rhe
+++ b/CommonConcepts/CommonConceptsTest/DslScripts/SimpleBusinessLogic.rhe
@@ -192,8 +192,15 @@ Module TestAuditable
         ShortString Name;
         Reference Parent TestAuditable.Parent;
         DateTime Started { CreationTime; }
-        DateTime ModifiedParentProperty { ModificationTimeOf TestAuditable.Simple.Parent; }
-        DateTime ModifiedNameOrParentModification { ModificationTimeOf TestAuditable.Simple.Name; ModificationTimeOf TestAuditable.Simple.ModifiedParentProperty; }
+        DateTime ModifiedParentProperty
+        {
+            ModificationTimeOf TestAuditable.Simple.Parent;
+        }
+        DateTime ModifiedNameOrParentModification
+        {
+            ModificationTimeOf TestAuditable.Simple.Name;
+            ModificationTimeOf TestAuditable.Simple.ModifiedParentProperty;
+        }
     }
 
     Entity Simple2

--- a/CommonConcepts/Plugins/Rhetos.CommonConcepts.Test/Mocks/DslModelMock.cs
+++ b/CommonConcepts/Plugins/Rhetos.CommonConcepts.Test/Mocks/DslModelMock.cs
@@ -31,12 +31,7 @@ namespace Rhetos.CommonConcepts.Test.Mocks
 
         public IConceptInfo FindByKey(string conceptKey)
         {
-            return this.Where(c => c.GetKey() == conceptKey).SingleOrDefault();
-        }
-
-        public IEnumerable<IConceptInfo> FindByType(Type conceptType)
-        {
-            return this.Where(c => conceptType.IsAssignableFrom(c.GetType()));
+            return this.SingleOrDefault(c => c.GetKey() == conceptKey);
         }
 
         public T GetIndex<T>() where T : IDslModelIndex

--- a/CommonConcepts/Plugins/Rhetos.CommonConcepts.Test/SqlAnalysisTest.cs
+++ b/CommonConcepts/Plugins/Rhetos.CommonConcepts.Test/SqlAnalysisTest.cs
@@ -253,14 +253,18 @@ namespace CommonConcepts.Test
                 { "select /*a.1(), */a.2() from a.3/*inner join a.4, a.5*/", "a.2, a.3" },
                 { "select a.1 from \"a\".\"2\", a.3", "a.2, a.3" },
                 { "select a.1 from a.2, /*a.3, a.4*/ a.5, [a.6], \"a.9\", 'a.11, a.12', a.13", "a.13, a.2, a.5" },
-                { "select a.1 from a/*xxx*/./*xxx*/2/*xxx*/ join /*xxx*/a.3", "a.2, a.3" }
+                { "select a.1 from a/*xxx*/./*xxx*/2/*xxx*/ join /*xxx*/a.3", "a.2, a.3" },
+
+                { "INSERT INTO a.b SELECT * FROM c.d", "a.b, c.d" },
+                { "MERGE INTO a.b USING c.d ON ...", "a.b, c.d" },
+                { "MERGE a.b USING c.d src ON ...", "a.b, c.d" },
             };
 
             foreach (var test in tests)
                 Assert.AreEqual(
                     test.Value,
                     TestUtility.Dump(ExtractPossibleObjectsAccessor(test.Key)),
-                    "Input: " + test.Key); 
+                    "Input: " + test.Key);
         }
 
         class SimpleConceptInfo : IConceptInfo

--- a/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/FilterExpression.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/FilterExpression.cs
@@ -141,7 +141,7 @@ namespace Rhetos.Dom.DefaultConcepts
                 if (node == _oldParameter)
                     return _newParameter;
                 else
-                    return node;
+                    return base.VisitParameter(node);
             }
         }
     }

--- a/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/Rhetos.Dom.DefaultConcepts.csproj
+++ b/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/Rhetos.Dom.DefaultConcepts.csproj
@@ -179,6 +179,7 @@
     <Compile Include="SimpleBusinessLogic\ActionCodeGenerator.cs" />
     <Compile Include="SimpleBusinessLogic\CreatedByCodeGenerator.cs" />
     <Compile Include="SimpleBusinessLogic\DefaultValueCodeGenerator.cs" />
+    <Compile Include="SimpleBusinessLogic\ModificationTimeOfInfrastructureCodeGenerator.cs" />
     <Compile Include="SimpleBusinessLogic\ModificationTimeOfCodeGenerator.cs" />
     <Compile Include="SimpleBusinessLogic\ImplementsQueryableInterfaceCodeGenerator.cs" />
     <Compile Include="SimpleBusinessLogic\AutoCodeCachedCodeGenerator.cs" />

--- a/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/SimpleBusinessLogic/ModificationTimeOfInfrastructureCodeGenerator.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/SimpleBusinessLogic/ModificationTimeOfInfrastructureCodeGenerator.cs
@@ -1,0 +1,60 @@
+﻿/*
+    Copyright (C) 2014 Omega software d.o.o.
+
+    This file is part of Rhetos.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using Rhetos.Compiler;
+using Rhetos.Dsl;
+using Rhetos.Dsl.DefaultConcepts;
+using Rhetos.Extensibility;
+using System.ComponentModel.Composition;
+
+namespace Rhetos.Dom.DefaultConcepts
+{
+    [Export(typeof(IConceptCodeGenerator))]
+    [ExportMetadata(MefProvider.Implements, typeof(ModificationTimeOfInfrastructureInfo))]
+    public class ModificationTimeOfInfrastructureCodeGenerator : IConceptCodeGenerator
+    {
+        public static readonly CsTag<ModificationTimeOfInfrastructureInfo> PropertyInitializationTag = "PropertyInitialization";
+        public static readonly CsTag<ModificationTimeOfInfrastructureInfo> UpdateModifiedTag = "UpdateModified";
+
+        public void GenerateCode(IConceptInfo conceptInfo, ICodeBuilder codeBuilder)
+        {
+            var info = (ModificationTimeOfInfrastructureInfo)conceptInfo;
+
+            string snippet =
+            $@"{{
+                var now = SqlUtility.GetDatabaseTime(_executionContext.SqlExecuter);
+                foreach (var newItem in insertedNew)
+                {{
+                    {PropertyInitializationTag.Evaluate(info)}
+                }}
+
+                bool updateModificationTime = true;
+                while (updateModificationTime)
+                {{
+                    updateModificationTime = false;
+                    {UpdateModifiedTag.Evaluate(info)}
+                }}
+            }}
+
+            ";
+
+            codeBuilder.InsertCode(snippet, WritableOrmDataStructureCodeGenerator.OldDataLoadedTag, info.DataStructure);
+        }
+    }
+}

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DataStructure/SamePropertyValue2Info.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DataStructure/SamePropertyValue2Info.cs
@@ -34,28 +34,37 @@ namespace Rhetos.Dsl.DefaultConcepts
     [Export(typeof(IConceptInfo))]
     [ConceptKeyword("SamePropertyValue")]
     [Obsolete("Use simpler SamePropertyValue syntax with a path to the base property.")]
-    public class SamePropertyValue2Info : SamePropertyValueInfo, IValidatedConcept, IAlternativeInitializationConcept
+    public class SamePropertyValue2Info : IValidatedConcept
     {
+        [ConceptKey]
+        public PropertyInfo DerivedProperty { get; set; }
+
         /// <summary>Object model property name on the inherited data structure that references the base data structure class.</summary>
+        [ConceptKey]
         public string BaseSelector { get; set; }
 
         public PropertyInfo BaseProperty { get; set; }
 
         public void CheckSemantics(IDslModel existingConcepts)
         {
-            DslUtility.ValidateIdentifier(BaseSelector, this, "BaseSelector should be set to a property name from '"
-                + DerivedProperty.DataStructure.GetKeyProperties() + "' class.");
+            DslUtility.ValidateIdentifier(BaseSelector, this,
+                $"BaseSelector should be set to a property name from '{DerivedProperty.DataStructure.FullName}' class.");
         }
+    }
 
-        public IEnumerable<string> DeclareNonparsableProperties()
+    [Export(typeof(IConceptMacro))]
+    public class SamePropertyValue2Macro : IConceptMacro<SamePropertyValue2Info>
+    {
+        public IEnumerable<IConceptInfo> CreateNewConcepts(SamePropertyValue2Info conceptInfo, IDslModel existingConcepts)
         {
-            return new string[] { "Path" };
-        }
-
-        public void InitializeNonparsableProperties(out IEnumerable<IConceptInfo> createdConcepts)
-        {
-            Path = BaseSelector + "." + BaseProperty.Name;
-            createdConcepts = new IConceptInfo[] {};
+            return new[]
+            {
+                new SamePropertyValueInfo
+                {
+                    DerivedProperty = conceptInfo.DerivedProperty,
+                    Path = conceptInfo.BaseSelector + "." + conceptInfo.BaseProperty.Name
+                }
+            };
         }
     }
 }

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DatabaseWorkarounds/SqlIndexClusteredFlatInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DatabaseWorkarounds/SqlIndexClusteredFlatInfo.cs
@@ -1,0 +1,59 @@
+﻿/*
+    Copyright (C) 2014 Omega software d.o.o.
+
+    This file is part of Rhetos.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+
+namespace Rhetos.Dsl.DefaultConcepts
+{
+    /// <summary>
+    /// This is a generic version of the Clustered concept syntax, that helps with DSL parser disambiguation.
+    /// This concept will be used if the Clustered keyword is placed flat in the Entity.
+    /// Other concepts with Clustered keyword will be used if the Clustered keyword is nested in a specific indexing concept.
+    /// </summary>
+    [Export(typeof(IConceptInfo))]
+    [ConceptKeyword("Clustered")]
+    public class SqlIndexClusteredFlatInfo : IConceptInfo
+    {
+        [ConceptKey]
+        public DataStructureInfo DataStructure { get; set; }
+
+        [ConceptKey]
+        public string PropertyNames { get; set; }
+    }
+
+    [Export(typeof(IConceptMacro))]
+    public class SqlIndexClusteredFlatMacro : IConceptMacro<SqlIndexClusteredFlatInfo>
+    {
+        public IEnumerable<IConceptInfo> CreateNewConcepts(SqlIndexClusteredFlatInfo conceptInfo, IDslModel existingConcepts)
+        {
+            return new[]
+            {
+                new SqlIndexClusteredInfo
+                {
+                    SqlIndex = new SqlIndexMultipleInfo
+                    {
+                        DataStructure = conceptInfo.DataStructure,
+                        PropertyNames = conceptInfo.PropertyNames
+                    }
+                }
+            };
+        }
+    }
+}

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/Rhetos.Dsl.DefaultConcepts.csproj
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/Rhetos.Dsl.DefaultConcepts.csproj
@@ -155,6 +155,7 @@
     <Compile Include="DatabaseWorkarounds\SqlIndexMultipleFollowingPropertyInfo.cs" />
     <Compile Include="DatabaseWorkarounds\SqlIndexPropertyClusteredInfo.cs" />
     <Compile Include="DatabaseWorkarounds\SqlNotNullInfo.cs" />
+    <Compile Include="DatabaseWorkarounds\SqlIndexClusteredFlatInfo.cs" />
     <Compile Include="DatabaseWorkarounds\UniqueClusteredInfo.cs" />
     <Compile Include="DataStructure\BeforeQueryWithParameterInfo.cs" />
     <Compile Include="DataStructure\EntryInfo.cs" />

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/Rhetos.Dsl.DefaultConcepts.csproj
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/Rhetos.Dsl.DefaultConcepts.csproj
@@ -308,6 +308,7 @@
     <Compile Include="SimpleBusinessLogic\CreatedByInfo.cs" />
     <Compile Include="SimpleBusinessLogic\DefaultValueInfo.cs" />
     <Compile Include="SimpleBusinessLogic\LogReaderAdditionalSourceInfo.cs" />
+    <Compile Include="SimpleBusinessLogic\ModificationTimeOfInfrastructureInfo.cs" />
     <Compile Include="SimpleBusinessLogic\ReferenceCascadeDeleteDbInfo.cs" />
     <Compile Include="SimpleBusinessLogic\ReferenceCascadeDeletePolymorphicInfo.cs" />
     <Compile Include="SimpleBusinessLogic\UniqueReferenceCascadeDeletePolymorphicInfo.cs" />

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/ModificationTimeOfInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/ModificationTimeOfInfo.cs
@@ -17,17 +17,14 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Linq;
-using System.Text;
 
 namespace Rhetos.Dsl.DefaultConcepts
 {
     [Export(typeof(IConceptInfo))]
     [ConceptKeyword("ModificationTimeOf")]
-    public class ModificationTimeOfInfo : IValidatedConcept
+    public class ModificationTimeOfInfo : IValidatedConcept, IAlternativeInitializationConcept
     {
         [ConceptKey]
         public DateTimePropertyInfo Property { get; set; }
@@ -35,9 +32,22 @@ namespace Rhetos.Dsl.DefaultConcepts
         [ConceptKey]
         public PropertyInfo ModifiedProperty { get; set; }
 
+        public ModificationTimeOfInfrastructureInfo Dependency_Infrastructure { get; set; }
+
         public void CheckSemantics(IDslModel existingConcepts)
         {
             DslUtility.CheckIfPropertyBelongsToDataStructure(ModifiedProperty, Property.DataStructure, this);
+        }
+
+        public IEnumerable<string> DeclareNonparsableProperties()
+        {
+            return new[] { nameof(Dependency_Infrastructure) };
+        }
+
+        public void InitializeNonparsableProperties(out IEnumerable<IConceptInfo> createdConcepts)
+        {
+            Dependency_Infrastructure = new ModificationTimeOfInfrastructureInfo { DataStructure = Property.DataStructure };
+            createdConcepts = new[] { Dependency_Infrastructure };
         }
     }
 

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/ModificationTimeOfInfrastructureInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/SimpleBusinessLogic/ModificationTimeOfInfrastructureInfo.cs
@@ -1,0 +1,30 @@
+﻿/*
+    Copyright (C) 2014 Omega software d.o.o.
+
+    This file is part of Rhetos.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using System.ComponentModel.Composition;
+
+namespace Rhetos.Dsl.DefaultConcepts
+{
+    [Export(typeof(IConceptInfo))]
+    public class ModificationTimeOfInfrastructureInfo : IConceptInfo
+    {
+        [ConceptKey]
+        public DataStructureInfo DataStructure { get; set; }
+    }
+}

--- a/Source/Rhetos.DatabaseGenerator.Test/DatabaseGeneratorTest.cs
+++ b/Source/Rhetos.DatabaseGenerator.Test/DatabaseGeneratorTest.cs
@@ -17,21 +17,17 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-using Rhetos.Utilities;
-using Rhetos.Compiler;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using Rhetos.Dsl;
-using System.Linq;
-using Rhetos.Extensibility;
-using Rhetos.Logging;
-using Rhetos.TestCommon;
-using Rhetos.DatabaseGenerator;
-using System.Text;
 using Autofac.Features.Indexed;
 using Autofac.Features.Metadata;
-using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Rhetos.Compiler;
+using Rhetos.Dsl;
+using Rhetos.Extensibility;
+using Rhetos.TestCommon;
+using Rhetos.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Rhetos.DatabaseGenerator.Test
 {
@@ -612,11 +608,9 @@ namespace Rhetos.DatabaseGenerator.Test
 
         class MockDslModel : IDslModel
         {
-            private readonly IEnumerable<IConceptInfo> _conceptInfos;
-            public MockDslModel(IEnumerable<IConceptInfo> conceptInfos) { _conceptInfos = conceptInfos; }
-            public IEnumerable<IConceptInfo> Concepts { get { return _conceptInfos; } }
+            public MockDslModel(IEnumerable<IConceptInfo> conceptInfos) { Concepts = conceptInfos; }
+            public IEnumerable<IConceptInfo> Concepts { get; private set; }
             public IConceptInfo FindByKey(string conceptKey) { throw new NotImplementedException(); }
-            public IEnumerable<IConceptInfo> FindByType(Type conceptType) { throw new NotImplementedException(); }
             public T GetIndex<T>() where T : IDslModelIndex
             {
                 throw new NotImplementedException();

--- a/Source/Rhetos.DatabaseGenerator.Test/DatabaseGeneratorTest.cs
+++ b/Source/Rhetos.DatabaseGenerator.Test/DatabaseGeneratorTest.cs
@@ -728,6 +728,11 @@ namespace Rhetos.DatabaseGenerator.Test
             return new Lazy<bool>(() => defaultValue);
         }
 
+        public Lazy<T> GetEnum<T>(string key, T defaultValue) where T : struct
+        {
+            return new Lazy<T>(() => defaultValue);
+        }
+
         public Lazy<int> GetInt(string key, int defaultValue)
         {
             return new Lazy<int>(() => defaultValue);

--- a/Source/Rhetos.Dsl.Interfaces/DslModelIndexByType.cs
+++ b/Source/Rhetos.Dsl.Interfaces/DslModelIndexByType.cs
@@ -17,13 +17,10 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using Rhetos.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Diagnostics.Contracts;
-using System.ComponentModel.Composition;
-using Rhetos.Utilities;
 
 namespace Rhetos.Dsl
 {

--- a/Source/Rhetos.Dsl.Test/DslContainerTest.cs
+++ b/Source/Rhetos.Dsl.Test/DslContainerTest.cs
@@ -33,7 +33,7 @@ namespace Rhetos.Dsl.Test
         class DslContainerAccessor : DslContainer
         {
             public DslContainerAccessor()
-                : base(new ConsoleLogProvider(), new MockPluginsContainer<IDslModelIndex>(new DslModelIndexByType()))
+                : base(new ConsoleLogProvider(), new MockPluginsContainer<IDslModelIndex>(new DslModelIndexByType()), new MockConfiguration())
             {
             }
         }

--- a/Source/Rhetos.Dsl.Test/DslModelTest.cs
+++ b/Source/Rhetos.Dsl.Test/DslModelTest.cs
@@ -127,8 +127,16 @@ namespace Rhetos.Dsl.Test
 
         static IDslModel NewDslModel(IDslParser parser, IEnumerable<IConceptInfo> conceptPrototypes)
         {
-            var dslContainter = new DslContainer(new ConsoleLogProvider(), new MockPluginsContainer<IDslModelIndex>(new DslModelIndexByType()));
-            var dslModel = new DslModel(parser, new ConsoleLogProvider(), dslContainter, new StubMacroIndex(), new IConceptMacro[] { }, conceptPrototypes, new StubMacroOrderRepository(), new StubDslModelFile());
+            var dslContainter = new DslContainer(new ConsoleLogProvider(), new MockPluginsContainer<IDslModelIndex>(new DslModelIndexByType()), new MockConfiguration());
+            var dslModel = new DslModel(
+                parser,
+                new ConsoleLogProvider(),
+                dslContainter,
+                new StubMacroIndex(),
+                new IConceptMacro[] { },
+                conceptPrototypes,
+                new StubMacroOrderRepository(),
+                new StubDslModelFile());
             return dslModel;
         }
 

--- a/Source/Rhetos.Dsl/DslModelFile.cs
+++ b/Source/Rhetos.Dsl/DslModelFile.cs
@@ -20,7 +20,6 @@
 using Newtonsoft.Json;
 using Rhetos.Logging;
 using Rhetos.Utilities;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -32,10 +31,7 @@ namespace Rhetos.Dsl
     public class DslModelFile : IDslModel, IDslModelFile
     {
         private readonly ILogger _performanceLogger;
-        private readonly ILogger _logger;
-        private readonly ILogger _dslModelConceptsLogger;
         private readonly DslContainer _dslContainer;
-        private readonly ISqlExecuter _sqlExecuter;
 
         public DslModelFile(
             ILogProvider logProvider,
@@ -43,10 +39,7 @@ namespace Rhetos.Dsl
             ISqlExecuter sqlExecuter)
         {
             _performanceLogger = logProvider.GetLogger("Performance");
-            _logger = logProvider.GetLogger(GetType().Name);
-            _dslModelConceptsLogger = logProvider.GetLogger("DslModelConcepts");
             _dslContainer = dslContainer;
-            _sqlExecuter = sqlExecuter;
         }
 
         #region IDslModel implementation
@@ -66,13 +59,6 @@ namespace Rhetos.Dsl
             if (!_initialized)
                 Initialize();
             return _dslContainer.FindByKey(conceptKey);
-        }
-
-        public IEnumerable<IConceptInfo> FindByType(Type conceptType)
-        {
-            if (!_initialized)
-                Initialize();
-            return _dslContainer.FindByType(conceptType);
         }
 
         public T GetIndex<T>() where T : IDslModelIndex

--- a/Source/Rhetos.Dsl/DslModelFile.cs
+++ b/Source/Rhetos.Dsl/DslModelFile.cs
@@ -103,6 +103,7 @@ namespace Rhetos.Dsl
                 PreserveReferencesHandling = PreserveReferencesHandling.All,
                 ReferenceLoopHandling = ReferenceLoopHandling.Serialize,
                 TypeNameHandling = TypeNameHandling.All,
+                Formatting = Formatting.Indented,
             };
 
             string serializedConcepts = JsonConvert.SerializeObject(concepts, serializerSettings);

--- a/Source/Rhetos.TestCommon/MockConfiguration.cs
+++ b/Source/Rhetos.TestCommon/MockConfiguration.cs
@@ -30,6 +30,8 @@ namespace Rhetos.TestCommon
     {
         public Lazy<bool> GetBool(string key, bool defaultValue) => Get(key, defaultValue);
 
+        public Lazy<T> GetEnum<T>(string key, T defaultValue) where T : struct => Get(key, defaultValue);
+
         public Lazy<int> GetInt(string key, int defaultValue) => Get(key, defaultValue);
 
         public Lazy<string> GetString(string key, string defaultValue) => Get(key, defaultValue);
@@ -37,7 +39,7 @@ namespace Rhetos.TestCommon
         private Lazy<T> Get<T>(string key, T defaultValue)
         {
             object value;
-            if (!this.TryGetValue(key, out value))
+            if (!TryGetValue(key, out value))
                 value = defaultValue;
             return new Lazy<T>(() => (T)value);
         }

--- a/Source/Rhetos.Utilities/Configuration.cs
+++ b/Source/Rhetos.Utilities/Configuration.cs
@@ -39,8 +39,7 @@ namespace Rhetos.Utilities
                 string value = ConfigUtility.GetAppSetting(key);
                 if (!string.IsNullOrEmpty(value))
                 {
-                    int result;
-                    if (int.TryParse(value, out result))
+                    if (int.TryParse(value, out int result))
                         return result;
                     throw new FrameworkException("Invalid '" + key + "' parameter in configuration file: '" + value + "' is not an integer value.");
                 }
@@ -56,10 +55,28 @@ namespace Rhetos.Utilities
                 string value = ConfigUtility.GetAppSetting(key);
                 if (!string.IsNullOrEmpty(value))
                 {
-                    bool result;
-                    if (bool.TryParse(value, out result))
+                    if (bool.TryParse(value, out bool result))
                         return result;
                     throw new FrameworkException("Invalid '" + key + "' parameter in configuration file: '" + value + "' is not a boolean value. Allowed values are True and False.");
+                }
+                else
+                    return defaultValue;
+            });
+        }
+
+        public Lazy<T> GetEnum<T>(string key, T defaultValue) where T: struct
+        {
+            return new Lazy<T>(() =>
+            {
+                var value = ConfigUtility.GetAppSetting(key);
+                if (!string.IsNullOrEmpty(value))
+                {
+                    if (Enum.TryParse(value, true, out T parsedValue))
+                        return parsedValue;
+                    else
+                        throw new FrameworkException(
+                            $"Invalid '{key}' parameter in configuration file: '{value}' is not a valid value." +
+                            $" Allowed values are: {string.Join(", ", Enum.GetNames(typeof(T)))}.");
                 }
                 else
                     return defaultValue;

--- a/Source/Rhetos.Utilities/IConfiguration.cs
+++ b/Source/Rhetos.Utilities/IConfiguration.cs
@@ -30,5 +30,6 @@ namespace Rhetos.Utilities
         Lazy<string> GetString(string key, string defaultValue);
         Lazy<int> GetInt(string key, int defaultValue);
         Lazy<bool> GetBool(string key, bool defaultValue);
+        Lazy<T> GetEnum<T>(string key, T defaultValue) where T : struct;
     }
 }

--- a/Source/Rhetos.Utilities/ScriptPositionReporting.cs
+++ b/Source/Rhetos.Utilities/ScriptPositionReporting.cs
@@ -30,17 +30,11 @@ namespace Rhetos.Utilities
     {
         public static int Line(string text, int position)
         {
-            Contract.Requires(text != null);
-            Contract.Requires(position >= 0 && position < text.Length);
-
             return text.Substring(0, position).Count(c => c == '\n') + 1;
         }
 
         public static int Column(string text, int position)
         {
-            Contract.Requires(text != null);
-            Contract.Requires(position >= 0 && position < text.Length);
-
             if (position == 0)
                 return 1;
             int end = text.LastIndexOf('\n', position - 1);
@@ -66,14 +60,10 @@ namespace Rhetos.Utilities
 
         public static string FollowingText(string text, int position, int maxLength)
         {
-            Contract.Requires(text != null);
-            Contract.Requires(position >= 0 && position < text.Length);
-            Contract.Requires(maxLength >= 0);
-
             if (position >= text.Length)
                 return "";
 
-            text = text.Substring(position);
+            text = text.Substring(position, maxLength * 2);
             text = string.Join(" ", text.Split(new char[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries));
             text = text.Limit(maxLength, "...");
             return text;

--- a/Source/Rhetos.Utilities/ScriptPositionReporting.cs
+++ b/Source/Rhetos.Utilities/ScriptPositionReporting.cs
@@ -63,7 +63,7 @@ namespace Rhetos.Utilities
             if (position >= text.Length)
                 return "";
 
-            text = text.Substring(position, maxLength * 2);
+            text = text.Substring(position, Math.Min(maxLength * 2, text.Length - position));
             text = string.Join(" ", text.Split(new char[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries));
             text = text.Limit(maxLength, "...");
             return text;


### PR DESCRIPTION
Many small internal improvements, base on testing of Rhetos 3.0 on an older project.
For review, see each commit as a stand-alone feature.

* Clean.bat: removed empty folders.
* DslModel.json file is indented for easier testing.
* Configuration reader for enum values.
* AutodetectSqlDependencies now detects INSERT INTO, MERGE and JOIN query parts.
* Last modification time of dependent dlls and resources is included in generated source.
* Improved error handling for SamePropertyValue.
* "Flat" syntax option for Clustered keyword to help avoid with "Ambiguous syntax"
* DSL parser disambiguation: flat syntax has priority over nested syntax.
* Bugfix: Backward compatibility of SamePropertyValue syntax.
* ExpressionVisitor implementation should call base methods.
* Bugfix: Multiple ModificationTimeOf on same entity may not detect some indirect property changes depending on the order of generated code snippets.
* Sorting DSL model by key, after macro evaluation, for easier testing.
* Refactoring DslModel: lazy instead of custom lock for cleaner data flow.
