### PR TITLE
Optimized polymorphic property implementation for a reference to…

### DIFF
--- a/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/HardcodedEntityTest.cs
+++ b/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/HardcodedEntityTest.cs
@@ -107,5 +107,22 @@ namespace CommonConcepts.Test
                 }, "It is not allowed to modify hard-coded data", "TestHardcodedEntity.SimpleHardcodedEntity");
             }
         }
+
+        [TestMethod]
+        public void HardcodedEntityAndPolymorphicTests()
+        {
+            using (var container = new RhetosTestContainer())
+            {
+                var repository = container.Resolve<Common.DomRepository>();
+
+                var implementation1 = new TestHardcodedEntity.ReferenceToHardcodedImplementation1 { ID = Guid.NewGuid() };
+                repository.TestHardcodedEntity.ReferenceToHardcodedImplementation1.Insert(implementation1);
+                var implementation2 = new TestHardcodedEntity.ReferenceToHardcodedImplementation2 { ID = Guid.NewGuid() };
+                repository.TestHardcodedEntity.ReferenceToHardcodedImplementation2.Insert(implementation2);
+
+                Assert.AreEqual(TestHardcodedEntity.SimpleHardcodedEntity.SpecialDescription, repository.TestHardcodedEntity.ReferenceToHardcoded.Query(x => x.ID == implementation1.ID).First().SimpleHardcodedEntityID.Value);
+                Assert.AreEqual(TestHardcodedEntity.SimpleHardcodedEntity.StatusWithoutIntPropertyDefined, repository.TestHardcodedEntity.ReferenceToHardcoded.Query(x => x.ID == implementation2.ID).First().SimpleHardcodedEntityID.Value);
+            }
+        }
     }
 }

--- a/CommonConcepts/CommonConceptsTest/DslScripts/HardcodedEntity.rhe
+++ b/CommonConcepts/CommonConceptsTest/DslScripts/HardcodedEntity.rhe
@@ -31,6 +31,27 @@ Module TestHardcodedEntity
         Reference SimpleHardcodedEntity { Required; }
     }
 
+	Polymorphic ReferenceToHardcoded
+	{
+		Reference SimpleHardcodedEntity;
+	}
+
+	Entity ReferenceToHardcodedImplementation1
+	{
+		Is TestHardcodedEntity.ReferenceToHardcoded
+		{
+			Implements TestHardcodedEntity.ReferenceToHardcoded.SimpleHardcodedEntity TestHardcodedEntity.SimpleHardcodedEntity.SpecialDescription;
+		}
+	}
+
+	Entity ReferenceToHardcodedImplementation2
+	{
+		Is TestHardcodedEntity.ReferenceToHardcoded
+		{
+			Implements TestHardcodedEntity.ReferenceToHardcoded.SimpleHardcodedEntity TestHardcodedEntity.SimpleHardcodedEntity.StatusWithoutIntPropertyDefined;
+		}        
+	}
+
     SqlQueryable HardcodedEntityInSqlTest
     "
         SELECT

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DataStructure/SubtypeImplementsReferenceToHardcodedEntityInfo.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DataStructure/SubtypeImplementsReferenceToHardcodedEntityInfo.cs
@@ -1,0 +1,50 @@
+﻿/*
+    Copyright (C) 2014 Omega software d.o.o.
+
+    This file is part of Rhetos.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Rhetos.Dsl;
+using Rhetos.Utilities;
+using System.ComponentModel.Composition;
+
+namespace Rhetos.Dsl.DefaultConcepts
+{
+    [Export(typeof(IConceptInfo))]
+    [ConceptKeyword("Implements")]
+    public class SubtypeImplementsReferenceToHardcodedEntityInfo : IMacroConcept
+    {
+        [ConceptKey]
+        public IsSubtypeOfInfo IsSubtypeOf { get; set; }
+
+        [ConceptKey]
+        public PropertyInfo Property { get; set; }
+
+        public EntryInfo Entry { get; set; }
+
+        IEnumerable<IConceptInfo> IMacroConcept.CreateNewConcepts(IEnumerable<IConceptInfo> existingConcepts)
+        {
+            return new List<IConceptInfo>
+            {
+                new SubtypeImplementsPropertyInfo{ IsSubtypeOf = IsSubtypeOf, Property = Property, Expression = "'" + Entry.GetIdentifier().ToString() + "'"}
+            };
+        }
+    }
+}

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/Rhetos.Dsl.DefaultConcepts.csproj
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/Rhetos.Dsl.DefaultConcepts.csproj
@@ -166,6 +166,7 @@
     <Compile Include="DataStructure\Properties\ReferencePropertyDbConstraintInfo.cs" />
     <Compile Include="DataStructure\RepositoryMemberInfo.cs" />
     <Compile Include="DataStructure\SamePropertyValueInfo.cs" />
+    <Compile Include="DataStructure\SubtypeImplementsReferenceToHardcodedEntityInfo.cs" />
     <Compile Include="DataStructure\UniqueReferenceInfo.cs" />
     <Compile Include="DataStructure\SamePropertyValue2Info.cs" />
     <Compile Include="DataStructure\WritableOrmDataStructureMacro.cs" />


### PR DESCRIPTION
I am not sure if the property "Property" should be of type "ReferencePropertyInfo".
If we do it this way we are bound only to the "ReferencePropertyInfo".
Another dilemma is weather to use a shorter syntax to define the concept "SubtypeImplementsReferenceToHardcodedEntityInfo" inside a rhe script.