### PR TITLE
DeployOptions and DatabaseOnly switch are no longer used in new build process

### DIFF
--- a/Source/DeployPackages.Test/AutofacConfigurationTest.cs
+++ b/Source/DeployPackages.Test/AutofacConfigurationTest.cs
@@ -20,15 +20,11 @@
 using Autofac;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Rhetos;
-using Rhetos.Deployment;
 using Rhetos.Dsl;
 using Rhetos.Logging;
 using Rhetos.TestCommon;
-using Rhetos.Utilities;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace DeployPackages.Test
 {
@@ -47,42 +43,32 @@ namespace DeployPackages.Test
         }
 
         [TestMethod]
-        public void CorrectRegistrationsDeployTime()
+        public void CorrectRegistrationsBuildTime()
         {
             var builder = new RhetosContainerBuilder(_configurationProvider, new NLogProvider())
-                .AddRhetosDeployment()
+                .AddRhetosBuild()
                 .AddProcessUserOverride();
 
             using (var container = builder.Build())
             {
                 var registrationsDump = DumpSortedRegistrations(container);
                 System.Diagnostics.Trace.WriteLine(registrationsDump);
-                TestUtility.AssertAreEqualByLine(_expectedRegistrationsDeploy, registrationsDump);
-
-                // in this scenario, IDslModel contains two registrations and it should resolve to DslModel, NOT DslModelFile
-                var dslModel = container.Resolve<IDslModel>();
-                Assert.AreEqual(typeof(DslModel), dslModel.GetType());
+                TestUtility.AssertAreEqualByLine(_expectedRegistrationsBuild, registrationsDump);
             }
         }
 
         [TestMethod]
-        public void CorrectRegistrationsDeployTimeDatabaseOnly()
+        public void CorrectRegistrationsDbUpdate()
         {
             var builder = new RhetosContainerBuilder(_configurationProvider, new NLogProvider())
-                .AddRhetosDeployment()
+                .AddRhetosDbUpdate()
                 .AddProcessUserOverride();
-
-            builder.RegisterInstance(new BuildOptions() { DatabaseOnly = true });
 
             using (var container = builder.Build())
             {
                 var registrationsDump = DumpSortedRegistrations(container);
                 System.Diagnostics.Trace.WriteLine(registrationsDump);
-                TestUtility.AssertAreEqualByLine(_expectedRegistrationsDeployDatabaseOnly, registrationsDump);
-
-                // in this scenario, IDslModel contains two registrations and it should resolve to DslModelFile, NOT DslModel
-                var dslModel = container.Resolve<IDslModel>();
-                Assert.AreEqual(typeof(DslModelFile), dslModel.GetType());
+                TestUtility.AssertAreEqualByLine(_expectedRegistrationsDbUpdate, registrationsDump);
             }
         }
 
@@ -129,7 +115,7 @@ namespace DeployPackages.Test
             return string.Join(Environment.NewLine, registrations);
         }
 
-        private static readonly string _expectedRegistrationsDeploy =
+        private static readonly string _expectedRegistrationsBuild =
 @"Activator = ApplicationGenerator (ReflectionActivator), Services = [Rhetos.Deployment.ApplicationGenerator], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = AssemblyGenerator (ReflectionActivator), Services = [Rhetos.Compiler.IAssemblyGenerator], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = AuthorizationManager (ReflectionActivator), Services = [Rhetos.Security.IAuthorizationManager], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
@@ -158,8 +144,7 @@ Activator = DiskDslScriptLoader (ReflectionActivator), Services = [Rhetos.Dsl.ID
 Activator = DomGenerator (ReflectionActivator), Services = [Rhetos.Dom.IDomainObjectModel], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = DomGeneratorOptions (DelegateActivator), Services = [Rhetos.Dom.DomGeneratorOptions], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = DslContainer (ReflectionActivator), Services = [Rhetos.Dsl.DslContainer], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
-Activator = DslModel (ReflectionActivator), Services = [Rhetos.Dsl.DslModel], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
-Activator = DslModelFile (ReflectionActivator), Services = [Rhetos.Dsl.IDslModel], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
+Activator = DslModel (ReflectionActivator), Services = [Rhetos.Dsl.IDslModel], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = DslModelFile (ReflectionActivator), Services = [Rhetos.Dsl.IDslModelFile], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = DslModelIndexByReference (ReflectionActivator), Services = [Rhetos.Dsl.IDslModelIndex], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = DslModelIndexByType (ReflectionActivator), Services = [Rhetos.Dsl.IDslModelIndex], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
@@ -167,7 +152,6 @@ Activator = DslParser (ReflectionActivator), Services = [Rhetos.Dsl.IDslParser],
 Activator = EntityFrameworkMappingGenerator (ReflectionActivator), Services = [Rhetos.Extensibility.IGenerator], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = FilesUtility (ReflectionActivator), Services = [Rhetos.Utilities.FilesUtility], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = GeneratedFilesCache (ReflectionActivator), Services = [Rhetos.Utilities.GeneratedFilesCache], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
-Activator = IDslModel (DelegateActivator), Services = [Rhetos.Dsl.IDslModel], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = InitializationConcept (ReflectionActivator), Services = [Rhetos.Dsl.IConceptInfo], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = InstalledPackages (ReflectionActivator), Services = [Rhetos.Deployment.IInstalledPackages], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = LifetimeScope (DelegateActivator), Services = [Autofac.ILifetimeScope, Autofac.IComponentContext], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = Shared, Ownership = ExternallyOwned
@@ -187,11 +171,10 @@ Activator = WcfWindowsUserInfo (ReflectionActivator), Services = [Rhetos.Utiliti
 Activator = WindowsSecurity (ReflectionActivator), Services = [Rhetos.Security.IWindowsSecurity], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = XmlUtility (ReflectionActivator), Services = [Rhetos.Utilities.XmlUtility], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope";
 
-        private static readonly string _expectedRegistrationsDeployDatabaseOnly =
+        private static readonly string _expectedRegistrationsDbUpdate =
 @"Activator = ApplicationGenerator (ReflectionActivator), Services = [Rhetos.Deployment.ApplicationGenerator], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = AssemblyGenerator (ReflectionActivator), Services = [Rhetos.Compiler.IAssemblyGenerator], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = AuthorizationManager (ReflectionActivator), Services = [Rhetos.Security.IAuthorizationManager], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
-Activator = BuildOptions (ProvidedInstanceActivator), Services = [Rhetos.Utilities.BuildOptions], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = BuildOptions (ProvidedInstanceActivator), Services = [Rhetos.Utilities.BuildOptions], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = CodeBuilder (ReflectionActivator), Services = [Rhetos.Compiler.ICodeBuilder], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = CodeGenerator (ReflectionActivator), Services = [Rhetos.Compiler.ICodeGenerator], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
@@ -217,7 +200,6 @@ Activator = DiskDslScriptLoader (ReflectionActivator), Services = [Rhetos.Dsl.ID
 Activator = DomGenerator (ReflectionActivator), Services = [Rhetos.Dom.IDomainObjectModel], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = DomGeneratorOptions (DelegateActivator), Services = [Rhetos.Dom.DomGeneratorOptions], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = DslContainer (ReflectionActivator), Services = [Rhetos.Dsl.DslContainer], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
-Activator = DslModel (ReflectionActivator), Services = [Rhetos.Dsl.DslModel], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = DslModelFile (ReflectionActivator), Services = [Rhetos.Dsl.IDslModel], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = DslModelFile (ReflectionActivator), Services = [Rhetos.Dsl.IDslModelFile], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = DslModelIndexByReference (ReflectionActivator), Services = [Rhetos.Dsl.IDslModelIndex], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
@@ -226,7 +208,6 @@ Activator = DslParser (ReflectionActivator), Services = [Rhetos.Dsl.IDslParser],
 Activator = EntityFrameworkMappingGenerator (ReflectionActivator), Services = [Rhetos.Extensibility.IGenerator], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = FilesUtility (ReflectionActivator), Services = [Rhetos.Utilities.FilesUtility], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = GeneratedFilesCache (ReflectionActivator), Services = [Rhetos.Utilities.GeneratedFilesCache], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
-Activator = IDslModel (DelegateActivator), Services = [Rhetos.Dsl.IDslModel], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = InitializationConcept (ReflectionActivator), Services = [Rhetos.Dsl.IConceptInfo], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = InstalledPackages (ReflectionActivator), Services = [Rhetos.Deployment.IInstalledPackages], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = LifetimeScope (DelegateActivator), Services = [Autofac.ILifetimeScope, Autofac.IComponentContext], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = Shared, Ownership = ExternallyOwned

--- a/Source/DeployPackages/DeployOptions.cs
+++ b/Source/DeployPackages/DeployOptions.cs
@@ -17,13 +17,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Rhetos.Deployment
+namespace DeployPackages
 {
     /// <summary>
     /// Options specific to DeployPackages utility. Should not be used outside of that scope.

--- a/Source/DeployPackages/DeployPackages.csproj
+++ b/Source/DeployPackages/DeployPackages.csproj
@@ -48,6 +48,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DeployOptions.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Rhetos\Properties\GlobalAssemblyInfo.cs">

--- a/Source/DeployPackages/Program.cs
+++ b/Source/DeployPackages/Program.cs
@@ -18,14 +18,12 @@
 */
 
 using Rhetos;
-using Rhetos.Deployment;
 using Rhetos.Logging;
 using Rhetos.Utilities;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 
 namespace DeployPackages
 {
@@ -63,7 +61,7 @@ namespace DeployPackages
                 if (deployOptions.StartPaused)
                     StartPaused();
 
-                var deployment = new Rhetos.ApplicationDeployment(configurationProvider, logProvider);
+                var deployment = new ApplicationDeployment(configurationProvider, logProvider);
                 if (!deployOptions.DatabaseOnly)
                 {
                     deployment.InitialCleanup();
@@ -116,7 +114,7 @@ namespace DeployPackages
         private static void StartPaused()
         {
             if (!Environment.UserInteractive)
-                throw new Rhetos.UserException("DeployPackages parameter 'StartPaused' must not be set, because the application is executed in a non-interactive environment.");
+                throw new UserException("DeployPackages parameter 'StartPaused' must not be set, because the application is executed in a non-interactive environment.");
 
             Console.WriteLine("Press any key to continue . . .");
             Console.ReadKey(true);

--- a/Source/Rhetos.Configuration.Autofac/ApplicationDeployment.cs
+++ b/Source/Rhetos.Configuration.Autofac/ApplicationDeployment.cs
@@ -36,7 +36,6 @@ namespace Rhetos
         private readonly ILogProvider _logProvider;
         private readonly RhetosAppEnvironment _rhetosAppEnvironment;
         private readonly FilesUtility _filesUtility;
-        private readonly DeployOptions _deployOptions;
 
         public ApplicationDeployment(IConfigurationProvider configurationProvider, ILogProvider logProvider)
         {
@@ -45,7 +44,6 @@ namespace Rhetos
             _logProvider = logProvider;
             _filesUtility = new FilesUtility(logProvider);
             _rhetosAppEnvironment = new RhetosAppEnvironment(_configurationProvider.GetOptions<RhetosAppOptions>().RootPath);
-            _deployOptions = configurationProvider.GetOptions<DeployOptions>();
             LegacyUtilities.Initialize(configurationProvider);
         }
 

--- a/Source/Rhetos.Configuration.Autofac/Modules/CoreModule.cs
+++ b/Source/Rhetos.Configuration.Autofac/Modules/CoreModule.cs
@@ -98,7 +98,6 @@ namespace Rhetos.Configuration.Autofac.Modules
             pluginRegistration.FindAndRegisterPlugins<IDslModelIndex>();
             builder.RegisterType<DslModelIndexByType>().As<IDslModelIndex>(); // This plugin is registered manually because FindAndRegisterPlugins does not scan core Rhetos dlls.
             builder.RegisterType<DslModelIndexByReference>().As<IDslModelIndex>(); // This plugin is registered manually because FindAndRegisterPlugins does not scan core Rhetos dlls.
-            builder.RegisterType<DslModelFile>().As<IDslModel>().SingleInstance();
         }
     }
 }

--- a/Source/Rhetos.Configuration.Autofac/RhetosContainerBuilderExtensions.cs
+++ b/Source/Rhetos.Configuration.Autofac/RhetosContainerBuilderExtensions.cs
@@ -33,21 +33,29 @@ namespace Rhetos
         {
             builder.RegisterModule(new CoreModule());
             builder.RegisterModule(new RuntimeModule());
+            builder.RegisterType<DslModelFile>().As<IDslModel>().SingleInstance();
             builder.RegisterModule(new ExtensibilityModule());
             return builder;
         }
 
-        public static RhetosContainerBuilder AddRhetosDeployment(this RhetosContainerBuilder builder)
+        public static RhetosContainerBuilder AddRhetosBuild(this RhetosContainerBuilder builder)
         {
             var buildOptions = builder.GetInitializationContext().ConfigurationProvider.GetOptions<BuildOptions>();
             builder.RegisterInstance(buildOptions).PreserveExistingDefaults();
             builder.RegisterModule(new CoreModule());
             builder.RegisterModule(new DeployModule());
+            builder.RegisterType<DslModel>().As<IDslModel>().SingleInstance();
+            builder.RegisterModule(new ExtensibilityModule());
+            return builder;
+        }
 
-            // Overriding IDslModel registration from core (DslModelFile), unless deploying DatabaseOnly.
-            builder.RegisterType<DslModel>();
-            builder.Register(context => context.Resolve<BuildOptions>().DatabaseOnly ? (IDslModel)context.Resolve<IDslModelFile>() : context.Resolve<DslModel>()).SingleInstance();
-
+        public static RhetosContainerBuilder AddRhetosDbUpdate(this RhetosContainerBuilder builder)
+        {
+            var buildOptions = builder.GetInitializationContext().ConfigurationProvider.GetOptions<BuildOptions>();
+            builder.RegisterInstance(buildOptions).PreserveExistingDefaults();
+            builder.RegisterModule(new CoreModule());
+            builder.RegisterModule(new DeployModule());
+            builder.RegisterType<DslModelFile>().As<IDslModel>().SingleInstance();
             builder.RegisterModule(new ExtensibilityModule());
             return builder;
         }

--- a/Source/Rhetos.DatabaseGenerator/ConceptApplicationRepository.cs
+++ b/Source/Rhetos.DatabaseGenerator/ConceptApplicationRepository.cs
@@ -68,8 +68,11 @@ namespace Rhetos.DatabaseGenerator
 
             var invalidCa = previoslyAppliedConcepts.FirstOrDefault(ca => ca.ConceptInfoKey == ObsoleteConceptApplicationMark);
             if (invalidCa != null)
-                throw new FrameworkException("Obsolete concept application loaded from database (Rhetos.ConceptApplication, ID = " + SqlUtility.GuidToString(invalidCa.Id)
-                    + "). Upgrade procedure for old version of the system should include deployment with empty DslScritps folder (using old version of Rhetos server and packages) to remove old database structure and keep the data.");
+                throw new FrameworkException($"Obsolete concept application loaded from database" +
+                    $" (Rhetos.ConceptApplication, ID = {SqlUtility.GuidToString(invalidCa.Id)})." +
+                    $" The update procedure for old version of the system should include deployment" +
+                    $" with empty DslScritps folder (using old version of Rhetos server and packages)" +
+                    $" to remove old database structure and keep the data.");
 
             return previoslyAppliedConcepts;
         }

--- a/Source/Rhetos.DatabaseGenerator/DatabaseModelFile.cs
+++ b/Source/Rhetos.DatabaseGenerator/DatabaseModelFile.cs
@@ -57,7 +57,16 @@ namespace Rhetos.DatabaseGenerator
         {
             var stopwatch = Stopwatch.StartNew();
 
-            var serializedModel = File.ReadAllText(DatabaseModelFilePath, Encoding.UTF8);
+            string serializedModel;
+            try
+            {
+                serializedModel = File.ReadAllText(DatabaseModelFilePath, Encoding.UTF8);
+            }
+            catch (FileNotFoundException ex)
+            {
+                throw new FrameworkException("Cannot update database because the database model was not generated." +
+                    " Please check that the build has completed successfully before updating the database.", ex);
+            }
             var databaseModel = JsonConvert.DeserializeObject<DatabaseModel>(serializedModel, JsonSerializerSettings);
             _performanceLogger.Write(stopwatch, $"{nameof(DatabaseModelFile)}.{nameof(Load)}.");
 

--- a/Source/Rhetos.Deployment/PackageDownloaderOptions.cs
+++ b/Source/Rhetos.Deployment/PackageDownloaderOptions.cs
@@ -26,6 +26,9 @@ namespace Rhetos.Deployment
 {
     public class PackageDownloaderOptions
     {
+        /// <summary>
+        /// Do not stop deployment if a NuGet package dependency has an incompatible version.
+        /// </summary>
         public bool IgnorePackageDependencies { get; set; }
     }
 }

--- a/Source/Rhetos.Deployment/Rhetos.Deployment.csproj
+++ b/Source/Rhetos.Deployment/Rhetos.Deployment.csproj
@@ -81,7 +81,6 @@
     <Compile Include="DataMigrationScript.cs" />
     <Compile Include="DataMigrationScriptsFromDisk.cs" />
     <Compile Include="DeploymentConfiguration.cs" />
-    <Compile Include="DeployOptions.cs" />
     <Compile Include="IDataMigrationScriptsProvider.cs" />
     <Compile Include="InstalledPackages.cs" />
     <Compile Include="LoggerForNuget.cs" />

--- a/Source/Rhetos.Dsl/DslContainer.cs
+++ b/Source/Rhetos.Dsl/DslContainer.cs
@@ -380,7 +380,7 @@ namespace Rhetos.Dsl
             else if (_sortConceptsMethod == SortConceptsMethod.KeyDescending)
             {
                 // This option can be used in testing (along with ascending sort) to detect missing dependencies between concepts
-                // (code generators might fail with "script does not contain tag", upgrade of empty database might fail with missing column, e.g.).
+                // (code generators might fail with "script does not contain tag", update of empty database might fail with missing column, e.g.).
                 _resolvedConcepts.Sort((a, b) => -GetOrderByKey(a).CompareTo(GetOrderByKey(b)));
                 _performanceLogger.Write(sw, "DslContainer.SortReferencesBeforeUsingConcept: Sort by key descending.");
             }

--- a/Source/Rhetos.Dsl/DslModel.cs
+++ b/Source/Rhetos.Dsl/DslModel.cs
@@ -28,6 +28,9 @@ using System.Text;
 
 namespace Rhetos.Dsl
 {
+    /// <summary>
+    /// Builds DslModel from DSL scripts.
+    /// </summary>
     public class DslModel : IDslModel
     {
         private readonly IDslParser _dslParser;

--- a/Source/Rhetos.Utilities/BuildOptions.cs
+++ b/Source/Rhetos.Utilities/BuildOptions.cs
@@ -29,8 +29,6 @@ namespace Rhetos.Utilities
     {
         public bool Debug { get; set; }
         public bool ShortTransactions { get; set; }
-        // redundant options with deploy options of the same name, one should be removed
-        public bool DatabaseOnly { get; set; }
         public bool DataMigration__SkipScriptsWithWrongOrder { get; set; } = true;
         public bool CommonConcepts__Legacy__AutoGeneratePolymorphicProperty { get; set; } = true;
         public bool CommonConcepts__Legacy__CascadeDeleteInDatabase { get; set; } = true;

--- a/Source/RhetosCli/Program.cs
+++ b/Source/RhetosCli/Program.cs
@@ -17,13 +17,12 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using Rhetos.Logging;
+using Rhetos.Utilities;
 using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using Rhetos.Deployment;
-using Rhetos.Logging;
-using Rhetos.Utilities;
 
 namespace Rhetos
 {
@@ -41,7 +40,6 @@ namespace Rhetos
                 var rhetosServerRootFolder = args[1];
 
                 var configurationProvider = BuildConfigurationProvider(args);
-                var deployOptions = configurationProvider.GetOptions<DeployOptions>();
                 var deployment = new ApplicationDeployment(configurationProvider, logProvider);
                 var rhetosAppEnvironment = new RhetosAppEnvironment(rhetosServerRootFolder);
 
@@ -49,7 +47,7 @@ namespace Rhetos
                 {
                     AppDomain.CurrentDomain.AssemblyResolve += GetSearchForAssemblyDelegate(
                         rhetosAppEnvironment.BinFolder);
-                    deployment.DownloadPackages(deployOptions.IgnoreDependencies);
+                    deployment.DownloadPackages(ignoreDependencies: false);
                 }
                 else if (string.Compare(command, "build", true) == 0)
                 {


### PR DESCRIPTION
Both are now internal features of DeployPackages.exe.
We might later add IgnoreDependencies switch to "rhetos restore", but it is a separate feature.