### PR TITLE
Logging modified database objects information by default

### DIFF
--- a/Source/DeployPackages/App.config
+++ b/Source/DeployPackages/App.config
@@ -50,6 +50,7 @@
       <logger name="AssemblyGenerator" level="Trace" writeTo="MainLog"/>
       <logger name="ClaimGenerator Claims" level="Trace" writeTo="MainLog"/>
       <logger name="DatabaseGenerator Concepts" level="Trace" writeTo="MainLog"/>
+      <logger name="DatabaseGenerator ModifiedObjects" level="Trace" writeTo="MainLog"/>
       <logger name="DeployPackages" level="Trace" writeTo="MainLog"/>
       <logger name="FileSyncer" level="Trace" writeTo="MainLog"/>
       <logger name="NuGet" level="Trace" writeTo="MainLog"/>

--- a/Source/Rhetos.DatabaseGenerator/DatabaseGenerator.cs
+++ b/Source/Rhetos.DatabaseGenerator/DatabaseGenerator.cs
@@ -38,6 +38,7 @@ namespace Rhetos.DatabaseGenerator
         private readonly ILogger _logger;
 		/// <summary>Special logger for keeping track of inserted/updated/deleted concept applications in database.</summary>
         private readonly ILogger _conceptsLogger;
+        private readonly ILogger _modifiedObjectsLogger;
         private readonly ILogger _deployPackagesLogger;
         private readonly ILogger _performanceLogger;
         private readonly DatabaseGeneratorOptions _options;
@@ -54,6 +55,7 @@ namespace Rhetos.DatabaseGenerator
             _conceptApplicationRepository = conceptApplicationRepository;
             _logger = logProvider.GetLogger("DatabaseGenerator");
             _conceptsLogger = logProvider.GetLogger("DatabaseGenerator Concepts");
+            _modifiedObjectsLogger = logProvider.GetLogger("DatabaseGenerator ModifiedObjects");
             _deployPackagesLogger = logProvider.GetLogger("DeployPackages");
             _performanceLogger = logProvider.GetLogger("Performance");
             _options = options;
@@ -145,7 +147,7 @@ namespace Rhetos.DatabaseGenerator
                 .ToList();
 
             foreach (string ca in changedApplications)
-                _logger.Trace(() => $"Changed concept application: {ca}\r\n{ReportDiff(oldApplicationsByKey[ca].CreateQuery, newApplicationsByKey[ca].CreateQuery)}");
+                _modifiedObjectsLogger.Trace(() => $"Changed concept application: {ca}\r\n{ReportDiff(oldApplicationsByKey[ca].CreateQuery, newApplicationsByKey[ca].CreateQuery)}");
 
             // Find dependent concepts applications to be regenerated:
 


### PR DESCRIPTION
This will help caching some performance issues with database update. It it sometimes difficult to reproduce the issue after the database was already updated.