### PR TITLE
Rhetos app environment

### DIFF
--- a/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/PathsTest.cs
+++ b/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/PathsTest.cs
@@ -36,11 +36,10 @@ namespace CommonConcepts.Test
                 defaultRhetosServerRootFolder = rhetos.GetDefaultRhetosServerRootFolder();
 
             var rootPath = defaultRhetosServerRootFolder;
-            var configurationProvider = new ConfigurationBuilder().
-                AddRhetosAppConfiguration(rootPath).Build();
-            Paths.Initialize(rootPath,
-                configurationProvider.GetOptions<RhetosAppOptions>(),
-                configurationProvider.GetOptions<AssetsOptions>());
+            var configurationProvider = new ConfigurationBuilder()
+                .AddRhetosAppConfiguration(rootPath)
+                .Build();
+            Paths.Initialize(configurationProvider.GetOptions<RhetosAppEnvironment>());
 
             Assert.AreEqual(rootPath, Paths.RhetosServerRootPath);
             Assert.AreEqual(Path.Combine(rootPath, "bin"), Paths.BinFolder);

--- a/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/Persistence/EntityFrameworkMetadata.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/Persistence/EntityFrameworkMetadata.cs
@@ -40,14 +40,14 @@ namespace Rhetos.Dom.DefaultConcepts.Persistence
         private MetadataWorkspace _metadataWorkspace;
         private bool _initialized;
         private readonly object _initializationLock = new object();
-        private readonly AssetsOptions _assetsOptions;
+        private readonly RhetosAppEnvironment _rhetosAppEnvironment;
         private readonly ConnectionString _connectionString;
 
-        public EntityFrameworkMetadata(AssetsOptions assetsOptions, ILogProvider logProvider, ConnectionString connectionString)
+        public EntityFrameworkMetadata(RhetosAppEnvironment rhetosAppEnvironment, ILogProvider logProvider, ConnectionString connectionString)
         {
             _performanceLogger = logProvider.GetLogger("Performance");
             _logger = logProvider.GetLogger(nameof(EntityFrameworkMetadata));
-            _assetsOptions = assetsOptions;
+            _rhetosAppEnvironment = rhetosAppEnvironment;
             _connectionString = connectionString;
         }
 
@@ -61,7 +61,7 @@ namespace Rhetos.Dom.DefaultConcepts.Persistence
                         {
                             var sw = Stopwatch.StartNew();
 
-                            var modelFilesPath = EntityFrameworkMapping.ModelFiles.Select(fileName => Path.Combine(_assetsOptions.AssetsFolder, fileName)).ToList();
+                            var modelFilesPath = EntityFrameworkMapping.ModelFiles.Select(fileName => Path.Combine(_rhetosAppEnvironment.AssetsFolder, fileName)).ToList();
                             SetProviderManifestTokenIfNeeded(sw, modelFilesPath);
 
                             _metadataWorkspace = new MetadataWorkspace(modelFilesPath, new Assembly[] { });

--- a/Source/DeployPackages.Test/AutofacConfigurationTest.cs
+++ b/Source/DeployPackages.Test/AutofacConfigurationTest.cs
@@ -43,8 +43,10 @@ namespace DeployPackages.Test
                 .AddRhetosAppEnvironment(new RhetosAppEnvironment
                 {
                     RootPath = rhetosAppRootPath,
-                    BinFolder = Path.Combine(rhetosAppRootPath, @"bin"),
-                    AssetsFolder = Path.Combine(rhetosAppRootPath, @"bin\Generated"),
+                    BinFolder = Path.Combine(rhetosAppRootPath, "bin"),
+                    AssetsFolder = Path.Combine(rhetosAppRootPath, "bin", "Generated"),
+                    LegacyPluginsFolder = Path.Combine(rhetosAppRootPath, "bin", "Plugins"),
+                    LegacyAssetsFolder = Path.Combine(rhetosAppRootPath, "Resources"),
                 })
                 .AddWebConfiguration(rhetosAppRootPath)
                 .AddKeyValue(nameof(RhetosAppEnvironment.AssetsFolder), AppDomain.CurrentDomain.BaseDirectory)

--- a/Source/DeployPackages.Test/AutofacConfigurationTest.cs
+++ b/Source/DeployPackages.Test/AutofacConfigurationTest.cs
@@ -27,6 +27,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Rhetos.Deployment;
+using System.IO;
 
 namespace DeployPackages.Test
 {
@@ -37,8 +38,15 @@ namespace DeployPackages.Test
 
         public AutofacConfigurationTest()
         {
+            string rhetosAppRootPath = AppDomain.CurrentDomain.BaseDirectory;
             _configurationProvider = new ConfigurationBuilder()
-                .AddRhetosAppConfiguration(AppDomain.CurrentDomain.BaseDirectory)
+                .AddRhetosAppEnvironment(new RhetosAppEnvironment
+                {
+                    RootPath = rhetosAppRootPath,
+                    BinFolder = Path.Combine(rhetosAppRootPath, @"bin"),
+                    AssetsFolder = Path.Combine(rhetosAppRootPath, @"bin\Generated"),
+                })
+                .AddWebConfiguration(rhetosAppRootPath)
                 .AddKeyValue(nameof(RhetosAppEnvironment.AssetsFolder), AppDomain.CurrentDomain.BaseDirectory)
                 .AddConfigurationManagerConfiguration()
                 .Build();
@@ -210,6 +218,7 @@ Activator = NullUserInfo (ReflectionActivator), Services = [Rhetos.Utilities.IUs
 Activator = PluginScannerCache (ReflectionActivator), Services = [Rhetos.Extensibility.IGenerator], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = ResourcesGenerator (ReflectionActivator), Services = [Rhetos.Extensibility.IGenerator], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = RhetosAppEnvironment (DelegateActivator), Services = [Rhetos.Utilities.RhetosAppEnvironment], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
+Activator = RhetosAppEnvironmentGenerator (ReflectionActivator), Services = [Rhetos.Extensibility.IGenerator], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = TestWebSecurityUserInfo (ReflectionActivator), Services = [Rhetos.Utilities.IUserInfo], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = Tokenizer (ReflectionActivator), Services = [Rhetos.Dsl.Tokenizer], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = XmlUtility (ReflectionActivator), Services = [Rhetos.Utilities.XmlUtility], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope";

--- a/Source/DeployPackages.Test/AutofacConfigurationTest.cs
+++ b/Source/DeployPackages.Test/AutofacConfigurationTest.cs
@@ -34,11 +34,12 @@ namespace DeployPackages.Test
     public class AutofacConfigurationTest
     {
         private readonly IConfigurationProvider _configurationProvider;
+
         public AutofacConfigurationTest()
         {
             _configurationProvider = new ConfigurationBuilder()
                 .AddRhetosAppConfiguration(AppDomain.CurrentDomain.BaseDirectory)
-                .AddKeyValue(nameof(AssetsOptions.AssetsFolder), AppDomain.CurrentDomain.BaseDirectory)
+                .AddKeyValue(nameof(RhetosAppEnvironment.AssetsFolder), AppDomain.CurrentDomain.BaseDirectory)
                 .AddConfigurationManagerConfiguration()
                 .Build();
 
@@ -174,7 +175,6 @@ namespace DeployPackages.Test
         const string _expectedRegistrationsBuild =
 @"Activator = ApplicationGenerator (ReflectionActivator), Services = [Rhetos.Deployment.ApplicationGenerator], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = AssemblyGenerator (ReflectionActivator), Services = [Rhetos.Compiler.IAssemblyGenerator], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
-Activator = AssetsOptions (DelegateActivator), Services = [Rhetos.Utilities.AssetsOptions], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = BuildOptions (DelegateActivator), Services = [Rhetos.Utilities.BuildOptions], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = CodeBuilder (ReflectionActivator), Services = [Rhetos.Compiler.ICodeBuilder], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = CodeGenerator (ReflectionActivator), Services = [Rhetos.Compiler.ICodeGenerator], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
@@ -209,13 +209,13 @@ Activator = NullImplementation (ReflectionActivator), Services = [Rhetos.Databas
 Activator = NullUserInfo (ReflectionActivator), Services = [Rhetos.Utilities.IUserInfo], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = PluginScannerCache (ReflectionActivator), Services = [Rhetos.Extensibility.IGenerator], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = ResourcesGenerator (ReflectionActivator), Services = [Rhetos.Extensibility.IGenerator], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
+Activator = RhetosAppEnvironment (DelegateActivator), Services = [Rhetos.Utilities.RhetosAppEnvironment], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = TestWebSecurityUserInfo (ReflectionActivator), Services = [Rhetos.Utilities.IUserInfo], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = Tokenizer (ReflectionActivator), Services = [Rhetos.Dsl.Tokenizer], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = XmlUtility (ReflectionActivator), Services = [Rhetos.Utilities.XmlUtility], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope";
 
         const string _expectedRegistrationsDbUpdate =
-@"Activator = AssetsOptions (DelegateActivator), Services = [Rhetos.Utilities.AssetsOptions], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
-Activator = BuildOptions (DelegateActivator), Services = [Rhetos.Utilities.BuildOptions], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
+@"Activator = BuildOptions (DelegateActivator), Services = [Rhetos.Utilities.BuildOptions], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = ConceptApplicationRepository (ReflectionActivator), Services = [Rhetos.DatabaseGenerator.IConceptApplicationRepository], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = ConceptDataMigrationExecuter (ReflectionActivator), Services = [Rhetos.DatabaseGenerator.IConceptDataMigrationExecuter], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = Configuration (ReflectionActivator), Services = [Rhetos.Utilities.IConfiguration], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
@@ -236,14 +236,14 @@ Activator = MsSqlExecuter (ReflectionActivator), Services = [Rhetos.Utilities.IS
 Activator = MsSqlUtility (ReflectionActivator), Services = [Rhetos.Utilities.ISqlUtility], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = NLogProvider (ReflectionActivator), Services = [Rhetos.Logging.ILogProvider], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = NullUserInfo (ReflectionActivator), Services = [Rhetos.Utilities.IUserInfo], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
+Activator = RhetosAppEnvironment (DelegateActivator), Services = [Rhetos.Utilities.RhetosAppEnvironment], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = SqlTransactionBatches (ReflectionActivator), Services = [Rhetos.Utilities.SqlTransactionBatches], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = SqlTransactionBatchesOptions (DelegateActivator), Services = [Rhetos.Utilities.SqlTransactionBatchesOptions], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = TestWebSecurityUserInfo (ReflectionActivator), Services = [Rhetos.Utilities.IUserInfo], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = XmlUtility (ReflectionActivator), Services = [Rhetos.Utilities.XmlUtility], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope";
 
         const string _expectedRegistrationsRuntimeWithInitialization =
-@"Activator = AssetsOptions (DelegateActivator), Services = [Rhetos.Utilities.AssetsOptions], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
-Activator = AuthorizationManager (ReflectionActivator), Services = [Rhetos.Security.IAuthorizationManager], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
+@"Activator = AuthorizationManager (ReflectionActivator), Services = [Rhetos.Security.IAuthorizationManager], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = Configuration (ReflectionActivator), Services = [Rhetos.Utilities.IConfiguration], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = ConfigurationProvider (ProvidedInstanceActivator), Services = [Rhetos.IConfigurationProvider], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = ConnectionString (ProvidedInstanceActivator), Services = [Rhetos.Utilities.ConnectionString], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
@@ -263,6 +263,7 @@ Activator = NullAuthorizationProvider (ReflectionActivator), Services = [Rhetos.
 Activator = PersistenceTransaction (ReflectionActivator), Services = [Rhetos.Persistence.IPersistenceTransaction], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = ProcessingEngine (ReflectionActivator), Services = [Rhetos.Processing.IProcessingEngine], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = ProcessUserInfo (ReflectionActivator), Services = [Rhetos.Utilities.IUserInfo], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
+Activator = RhetosAppEnvironment (DelegateActivator), Services = [Rhetos.Utilities.RhetosAppEnvironment], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = RhetosAppOptions (DelegateActivator), Services = [Rhetos.Utilities.RhetosAppOptions], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = SecurityOptions (DelegateActivator), Services = [Rhetos.Utilities.SecurityOptions], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = SqlTransactionBatches (ReflectionActivator), Services = [Rhetos.Utilities.SqlTransactionBatches], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
@@ -273,8 +274,7 @@ Activator = XmlDataTypeProvider (ReflectionActivator), Services = [Rhetos.Proces
 Activator = XmlUtility (ReflectionActivator), Services = [Rhetos.Utilities.XmlUtility], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope";
 
         const string _expectedRegistrationsServerRuntime =
-@"Activator = AssetsOptions (DelegateActivator), Services = [Rhetos.Utilities.AssetsOptions], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
-Activator = AuthorizationManager (ReflectionActivator), Services = [Rhetos.Security.IAuthorizationManager], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
+@"Activator = AuthorizationManager (ReflectionActivator), Services = [Rhetos.Security.IAuthorizationManager], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = Configuration (ReflectionActivator), Services = [Rhetos.Utilities.IConfiguration], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = ConfigurationProvider (ProvidedInstanceActivator), Services = [Rhetos.IConfigurationProvider], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = ConnectionString (ProvidedInstanceActivator), Services = [Rhetos.Utilities.ConnectionString], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
@@ -294,6 +294,7 @@ Activator = NoLocalizer (ReflectionActivator), Services = [Rhetos.Utilities.ILoc
 Activator = NullAuthorizationProvider (ReflectionActivator), Services = [Rhetos.Security.IAuthorizationProvider], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = PersistenceTransaction (ReflectionActivator), Services = [Rhetos.Persistence.IPersistenceTransaction], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = ProcessingEngine (ReflectionActivator), Services = [Rhetos.Processing.IProcessingEngine], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
+Activator = RhetosAppEnvironment (DelegateActivator), Services = [Rhetos.Utilities.RhetosAppEnvironment], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = RhetosAppOptions (DelegateActivator), Services = [Rhetos.Utilities.RhetosAppOptions], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope
 Activator = RhetosService (ReflectionActivator), Services = [Rhetos.RhetosService, Rhetos.IServerApplication], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope
 Activator = SecurityOptions (DelegateActivator), Services = [Rhetos.Utilities.SecurityOptions], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope

--- a/Source/DeployPackages/Program.cs
+++ b/Source/DeployPackages/Program.cs
@@ -53,31 +53,60 @@ namespace DeployPackages
                 if (!ValidateArguments(args))
                     return 1;
 
-                var configurationProvider = BuildConfigurationProvider(args);
-                var deployOptions = configurationProvider.GetOptions<DeployOptions>();
-
-                pauseOnError = !deployOptions.NoPause;
-
-                if (deployOptions.StartPaused)
-                    StartPaused();
-
-                var deployment = new ApplicationDeployment(configurationProvider, logProvider, LegacyUtilities.GetListAssembliesDelegate());
-                if (!deployOptions.DatabaseOnly)
+                string rhetosAppRootPath = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ".."));
+                
+                // Using build-time configuration:
                 {
-                    DeleteObsoleteFiles(logProvider, logger);
-                    var installedPackages = deployment.DownloadPackages(deployOptions.IgnoreDependencies);
-                    deployment.GenerateApplication(installedPackages);
-                }
-                else
-                {
-                    logger.Info("Skipped deleting old generated files (DeployDatabaseOnly).");
-                    logger.Info("Skipped download packages (DeployDatabaseOnly).");
-                    logger.Info("Skipped code generators (DeployDatabaseOnly).");
+                    var configurationProvider = new ConfigurationBuilder()
+                        .AddRhetosAppEnvironment(new RhetosAppEnvironment
+                        {
+                            RootPath = rhetosAppRootPath,
+                            BinFolder = Path.Combine(rhetosAppRootPath, @"bin"),
+                            AssetsFolder = Path.Combine(rhetosAppRootPath, @"bin\Generated"),
+                        })
+                        .AddKeyValue(nameof(BuildOptions.CacheFolder), Path.Combine(rhetosAppRootPath, "GeneratedFilesCache"))
+                        .AddKeyValue(nameof(BuildOptions.GeneratedSourceFolder), Path.Combine(rhetosAppRootPath, @"bin\Generated"))
+                        .AddWebConfiguration(rhetosAppRootPath)
+                        .AddConfigurationManagerConfiguration()
+                        .AddCommandLineArguments(args, "/")
+                        .Build();
+
+                    var deployOptions = configurationProvider.GetOptions<DeployOptions>();
+
+                    pauseOnError = !deployOptions.NoPause;
+
+                    if (deployOptions.StartPaused)
+                        StartPaused();
+
+                    var deployment = new ApplicationDeployment(configurationProvider, logProvider, LegacyUtilities.GetListAssembliesDelegate());
+                    if (!deployOptions.DatabaseOnly)
+                    {
+                        DeleteObsoleteFiles(logProvider, logger);
+                        var installedPackages = deployment.DownloadPackages(deployOptions.IgnoreDependencies);
+                        deployment.GenerateApplication(installedPackages);
+                    }
+                    else
+                    {
+                        logger.Info("Skipped deleting old generated files (DeployDatabaseOnly).");
+                        logger.Info("Skipped download packages (DeployDatabaseOnly).");
+                        logger.Info("Skipped code generators (DeployDatabaseOnly).");
+                    }
                 }
 
-                deployment.UpdateDatabase();
-                deployment.InitializeGeneratedApplication();
-                deployment.RestartWebServer();
+                // Using run-time configuration:
+                {
+                    var configurationProvider = new ConfigurationBuilder()
+                        .AddRhetosAppConfiguration(rhetosAppRootPath)
+                        .AddConfigurationManagerConfiguration()
+                        .AddCommandLineArguments(args, "/")
+                        .Build();
+
+                    var deployment = new ApplicationDeployment(configurationProvider, logProvider, LegacyUtilities.GetListAssembliesDelegate());
+
+                    deployment.UpdateDatabase();
+                    deployment.InitializeGeneratedApplication();
+                    deployment.RestartWebServer();
+                }
 
                 logger.Trace("Done.");
             }
@@ -96,19 +125,6 @@ namespace DeployPackages
             }
 
             return 0;
-        }
-
-        private static IConfigurationProvider BuildConfigurationProvider(string[] args)
-        {
-            string rhetosAppRootPath = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ".."));
-
-            return new ConfigurationBuilder()
-                .AddKeyValue(nameof(BuildOptions.CacheFolder), Path.Combine(rhetosAppRootPath, "GeneratedFilesCache"))
-                .AddKeyValue(nameof(BuildOptions.GeneratedSourceFolder), Path.Combine(rhetosAppRootPath, "bin\\Generated"))
-                .AddRhetosAppConfiguration(rhetosAppRootPath)
-                .AddConfigurationManagerConfiguration()
-                .AddCommandLineArguments(args, "/")
-                .Build();
         }
 
         /// <summary>

--- a/Source/Rhetos.Configuration.Autofac/ApplicationDeployment.cs
+++ b/Source/Rhetos.Configuration.Autofac/ApplicationDeployment.cs
@@ -66,10 +66,6 @@ namespace Rhetos
 
         public void GenerateApplication(InstalledPackages installedPackages)
         {
-            _filesUtility.EmptyDirectory(_configurationProvider.GetOptions<AssetsOptions>().AssetsFolder);
-            _filesUtility.EmptyDirectory(_configurationProvider.GetOptions<BuildOptions>().GeneratedSourceFolder);
-            _filesUtility.SafeCreateDirectory(_configurationProvider.GetOptions<BuildOptions>().CacheFolder); // Cache should not be deleted between builds.
-
             _logger.Trace("Loading plugins.");
             var stopwatch = Stopwatch.StartNew();
 
@@ -80,7 +76,7 @@ namespace Rhetos
                 var performanceLogger = container.Resolve<ILogProvider>().GetLogger("Performance");
                 performanceLogger.Write(stopwatch, "DeployPackages.Program: Modules and plugins registered.");
                 ContainerBuilderPluginRegistration.LogRegistrationStatistics("Generating application", container, _logProvider);
-
+                
                 container.Resolve<ApplicationGenerator>().ExecuteGenerators();
             }
         }

--- a/Source/Rhetos.Configuration.Autofac/ApplicationDeployment.cs
+++ b/Source/Rhetos.Configuration.Autofac/ApplicationDeployment.cs
@@ -39,7 +39,6 @@ namespace Rhetos
         private readonly IConfigurationProvider _configurationProvider;
         private readonly ILogProvider _logProvider;
         private readonly Func<IEnumerable<string>> _pluginAssemblies;
-        private readonly FilesUtility _filesUtility;
 
         /// <param name="pluginAssemblies">List of assemblies (DLL file paths) that will be scanned for plugins.</param>
         public ApplicationDeployment(IConfigurationProvider configurationProvider, ILogProvider logProvider, Func<IEnumerable<string>> pluginAssemblies)
@@ -48,7 +47,6 @@ namespace Rhetos
             _configurationProvider = configurationProvider;
             _logProvider = logProvider;
             _pluginAssemblies = pluginAssemblies;
-            _filesUtility = new FilesUtility(logProvider);
             LegacyUtilities.Initialize(configurationProvider);
         }
 

--- a/Source/Rhetos.Configuration.Autofac/Modules/BuildModule.cs
+++ b/Source/Rhetos.Configuration.Autofac/Modules/BuildModule.cs
@@ -41,6 +41,7 @@ namespace Rhetos.Configuration.Autofac.Modules
             AddDsl(builder, pluginRegistration);
             AddPersistence(builder, pluginRegistration);
             AddCompiler(builder, pluginRegistration);
+            builder.RegisterType<RhetosAppEnvironmentGenerator>().As<IGenerator>();
             builder.RegisterType<DomGenerator>().As<IGenerator>();
             builder.RegisterType<ResourcesGenerator>().As<IGenerator>();
             builder.RegisterType<PluginScannerCache>().As<IGenerator>();

--- a/Source/Rhetos.Configuration.Autofac/Modules/CoreModule.cs
+++ b/Source/Rhetos.Configuration.Autofac/Modules/CoreModule.cs
@@ -35,7 +35,7 @@ namespace Rhetos.Configuration.Autofac.Modules
 
         private void AddCommon(ContainerBuilder builder)
         {
-            builder.Register(context => context.Resolve<IConfigurationProvider>().GetOptions<AssetsOptions>()).SingleInstance().PreserveExistingDefaults();
+            builder.Register(context => context.Resolve<IConfigurationProvider>().GetOptions<RhetosAppEnvironment>()).SingleInstance().PreserveExistingDefaults();
             builder.RegisterType<NLogProvider>().As<ILogProvider>().InstancePerLifetimeScope();
         }
 

--- a/Source/Rhetos.Configuration.Autofac/Modules/RuntimeModule.cs
+++ b/Source/Rhetos.Configuration.Autofac/Modules/RuntimeModule.cs
@@ -36,7 +36,7 @@ namespace Rhetos.Configuration.Autofac.Modules
         protected override void Load(ContainerBuilder builder)
         {
             var pluginRegistration = builder.GetPluginRegistration();
-            builder.Register(context => new InstalledPackagesProvider(context.Resolve<ILogProvider>(), context.Resolve<AssetsOptions>()).Load()).As<InstalledPackages>().As<IInstalledPackages>().SingleInstance();
+            builder.Register(context => new InstalledPackagesProvider(context.Resolve<ILogProvider>(), context.Resolve<RhetosAppEnvironment>()).Load()).As<InstalledPackages>().As<IInstalledPackages>().SingleInstance();
             builder.Register(context => context.Resolve<IConfigurationProvider>().GetOptions<RhetosAppOptions>()).SingleInstance().PreserveExistingDefaults();
             builder.RegisterType<DomLoader>().As<IDomainObjectModel>().SingleInstance();
             builder.RegisterType<PersistenceTransaction>().As<IPersistenceTransaction>().InstancePerLifetimeScope();

--- a/Source/Rhetos.Configuration.Autofac/RhetosContainerBuilder.cs
+++ b/Source/Rhetos.Configuration.Autofac/RhetosContainerBuilder.cs
@@ -44,7 +44,7 @@ namespace Rhetos
         {
             this.RegisterInstance(configurationProvider);
 
-            var pluginScanner = new PluginScanner(pluginAssemblies, configurationProvider.GetOptions<BuildOptions>(), configurationProvider.GetOptions<AssetsOptions>(), logProvider);
+            var pluginScanner = new PluginScanner(pluginAssemblies, configurationProvider.GetOptions<BuildOptions>(), configurationProvider.GetOptions<RhetosAppEnvironment>(), logProvider);
 
             // make properties accessible to modules which are provided with new/unique instance of ContainerBuilder
             this.Properties.Add(nameof(IPluginScanner), pluginScanner);

--- a/Source/Rhetos.Configuration.Autofac/RhetosTestContainer.cs
+++ b/Source/Rhetos.Configuration.Autofac/RhetosTestContainer.cs
@@ -155,7 +155,7 @@ namespace Rhetos.Configuration.Autofac
             AppDomain.CurrentDomain.AssemblyResolve += SearchForAssembly;
 
             // General registrations:
-            var builder = new RhetosContainerBuilder(configurationProvider, new ConsoleLogProvider(), LegacyUtilities.GetListAssembliesDelegate());
+            var builder = new RhetosContainerBuilder(configurationProvider, new ConsoleLogProvider(), LegacyUtilities.GetListAssembliesDelegate(configurationProvider));
             builder.AddRhetosRuntime();
             builder.AddPluginModules();
 

--- a/Source/Rhetos.DatabaseGenerator.Test/ConceptApplicationRepositoryTest.cs
+++ b/Source/Rhetos.DatabaseGenerator.Test/ConceptApplicationRepositoryTest.cs
@@ -81,7 +81,6 @@ namespace Rhetos.DatabaseGenerator.Test
         public ConceptApplicationRepositoryTest()
         {
             var configurationProvider = new ConfigurationBuilder()
-                .AddRhetosAppConfiguration(AppDomain.CurrentDomain.BaseDirectory)
                 .AddConfigurationManagerConfiguration()
                 .Build();
             LegacyUtilities.Initialize(configurationProvider);

--- a/Source/Rhetos.DatabaseGenerator.Test/DatabaseGeneratorTest.cs
+++ b/Source/Rhetos.DatabaseGenerator.Test/DatabaseGeneratorTest.cs
@@ -34,7 +34,6 @@ namespace Rhetos.DatabaseGenerator.Test
         public DatabaseGeneratorTest()
         {
             var configurationProvider = new ConfigurationBuilder()
-                .AddRhetosAppConfiguration(AppDomain.CurrentDomain.BaseDirectory)
                 .AddConfigurationManagerConfiguration()
                 .Build();
             LegacyUtilities.Initialize(configurationProvider);

--- a/Source/Rhetos.DatabaseGenerator/ConceptDataMigrationExecuter.cs
+++ b/Source/Rhetos.DatabaseGenerator/ConceptDataMigrationExecuter.cs
@@ -33,19 +33,19 @@ namespace Rhetos.DatabaseGenerator
         private readonly ILogger _deployPackagesLogger;
         private readonly SqlTransactionBatches _sqlExecuter;
         private readonly Lazy<GeneratedDataMigrationScripts> _scripts;
-        private readonly AssetsOptions _assetsOptions;
+        private readonly RhetosAppEnvironment _rhetosAppEnvironment;
 
         public IEnumerable<string> Dependencies => new List<string>();
 
         public ConceptDataMigrationExecuter(
             ILogProvider logProvider,
             SqlTransactionBatches sqlExecuter,
-            AssetsOptions assetsOptions)
+            RhetosAppEnvironment rhetosAppEnvironment)
         {
             _deployPackagesLogger = logProvider.GetLogger("DeployPackages");
             _sqlExecuter = sqlExecuter;
             _scripts = new Lazy<GeneratedDataMigrationScripts>(LoadScripts);
-            _assetsOptions = assetsOptions;
+            _rhetosAppEnvironment = rhetosAppEnvironment;
         }
 
         public void ExecuteBeforeDataMigrationScripts()
@@ -72,7 +72,7 @@ namespace Rhetos.DatabaseGenerator
 
         private GeneratedDataMigrationScripts LoadScripts()
         {
-            var serializedConcepts = File.ReadAllText(Path.Combine(_assetsOptions.AssetsFolder, ConceptDataMigrationGenerator.ConceptDataMigrationScriptsFileName), Encoding.UTF8);
+            var serializedConcepts = File.ReadAllText(Path.Combine(_rhetosAppEnvironment.AssetsFolder, ConceptDataMigrationGenerator.ConceptDataMigrationScriptsFileName), Encoding.UTF8);
             return JsonConvert.DeserializeObject<GeneratedDataMigrationScripts>(serializedConcepts);
         }
     }

--- a/Source/Rhetos.DatabaseGenerator/ConceptDataMigrationGenerator.cs
+++ b/Source/Rhetos.DatabaseGenerator/ConceptDataMigrationGenerator.cs
@@ -42,21 +42,21 @@ namespace Rhetos.DatabaseGenerator
         private readonly ILogger _logger;
         private readonly IDslModel _dslModel;
         private readonly IPluginsContainer<IConceptDataMigration> _plugins;
-        private readonly AssetsOptions _assetsOptions;
+        private readonly RhetosAppEnvironment _rhetosAppEnvironment;
 
         public IEnumerable<string> Dependencies => new List<string>();
 
         public ConceptDataMigrationGenerator(
             ILogProvider logProvider,
             IDslModel dslModel,
-            AssetsOptions assetsOptions,
+            RhetosAppEnvironment rhetosAppEnvironment,
             IPluginsContainer<IConceptDataMigration> plugins)
         {
             _performanceLogger = logProvider.GetLogger("Performance");
             _logger = logProvider.GetLogger(GetType().Name);
             _dslModel = dslModel;
             _plugins = plugins;
-            _assetsOptions = assetsOptions;
+            _rhetosAppEnvironment = rhetosAppEnvironment;
         }
 
         public void Generate()
@@ -83,7 +83,7 @@ namespace Rhetos.DatabaseGenerator
             _performanceLogger.Write(stopwatch, "ConceptDataMigrationGenerator: Scripts generated.");
 
             string serializedConcepts = JsonConvert.SerializeObject(codeBuilder.GetDataMigrationScripts(), Formatting.Indented);
-            File.WriteAllText(Path.Combine(_assetsOptions.AssetsFolder, ConceptDataMigrationScriptsFileName), serializedConcepts, Encoding.UTF8);
+            File.WriteAllText(Path.Combine(_rhetosAppEnvironment.AssetsFolder, ConceptDataMigrationScriptsFileName), serializedConcepts, Encoding.UTF8);
         }
     }
 }

--- a/Source/Rhetos.DatabaseGenerator/DatabaseModelFile.cs
+++ b/Source/Rhetos.DatabaseGenerator/DatabaseModelFile.cs
@@ -31,16 +31,16 @@ namespace Rhetos.DatabaseGenerator
         private readonly ILogger _performanceLogger;
 
         private const string DatabaseModelFileName = "DatabaseModel.json";
-        private readonly AssetsOptions _assetsOptions;
+        private readonly RhetosAppEnvironment _rhetosAppEnvironment;
 
-        private string DatabaseModelFilePath => Path.Combine(_assetsOptions.AssetsFolder, DatabaseModelFileName);
+        private string DatabaseModelFilePath => Path.Combine(_rhetosAppEnvironment.AssetsFolder, DatabaseModelFileName);
 
         public DatabaseModelFile(
             ILogProvider logProvider,
-            AssetsOptions assetsOptions)
+            RhetosAppEnvironment rhetosAppEnvironment)
         {
             _performanceLogger = logProvider.GetLogger("Performance");
-            _assetsOptions = assetsOptions;
+            _rhetosAppEnvironment = rhetosAppEnvironment;
         }
 
         public void Save(DatabaseModel databaseModel)

--- a/Source/Rhetos.Deployment.Interfaces/ContentFile.cs
+++ b/Source/Rhetos.Deployment.Interfaces/ContentFile.cs
@@ -18,8 +18,11 @@
 */
 
 
+using System.Diagnostics;
+
 namespace Rhetos.Deployment
 {
+    [DebuggerDisplay("{InPackagePath}")]
     public class ContentFile
     {
         /// <summary>

--- a/Source/Rhetos.Deployment.Test/DatabaseCleanerTest.cs
+++ b/Source/Rhetos.Deployment.Test/DatabaseCleanerTest.cs
@@ -35,7 +35,6 @@ namespace Rhetos.Deployment.Test
         public DatabaseCleanerTest()
         {
             var configurationProvider = new ConfigurationBuilder()
-                .AddRhetosAppConfiguration(AppDomain.CurrentDomain.BaseDirectory)
                 .AddConfigurationManagerConfiguration()
                 .Build();
 

--- a/Source/Rhetos.Deployment/ApplicationGenerator.cs
+++ b/Source/Rhetos.Deployment/ApplicationGenerator.cs
@@ -32,19 +32,32 @@ namespace Rhetos.Deployment
         private readonly ILogger _deployPackagesLogger;
         private readonly IDslModel _dslModel;
         private readonly IPluginsContainer<IGenerator> _generatorsContainer;
+        private readonly RhetosAppEnvironment _rhetosAppEnvironment;
+        private readonly BuildOptions _buildOptions;
+        private readonly FilesUtility _filesUtility;
 
         public ApplicationGenerator(
             ILogProvider logProvider,
             IDslModel dslModel,
-            IPluginsContainer<IGenerator> generatorsContainer)
+            IPluginsContainer<IGenerator> generatorsContainer,
+            RhetosAppEnvironment rhetosAppEnvironment,
+            BuildOptions buildOptions,
+            FilesUtility filesUtility)
         {
             _deployPackagesLogger = logProvider.GetLogger("DeployPackages");
             _dslModel = dslModel;
             _generatorsContainer = generatorsContainer;
+            _rhetosAppEnvironment = rhetosAppEnvironment;
+            _buildOptions = buildOptions;
+            _filesUtility = filesUtility;
         }
 
         public void ExecuteGenerators()
         {
+            _filesUtility.EmptyDirectory(_rhetosAppEnvironment.AssetsFolder);
+            _filesUtility.EmptyDirectory(_buildOptions.GeneratedSourceFolder);
+            _filesUtility.SafeCreateDirectory(_buildOptions.CacheFolder); // Cache is not deleted between builds.
+
             CheckDslModelErrors();
 
             var generators = GetSortedGenerators();

--- a/Source/Rhetos.Deployment/DataMigrationScriptsFile.cs
+++ b/Source/Rhetos.Deployment/DataMigrationScriptsFile.cs
@@ -32,14 +32,14 @@ namespace Rhetos.Deployment
         const string DataMigrationScriptsFileName = "DataMigrationScripts.json";
 
         private readonly ILogger _performanceLogger;
-        private readonly AssetsOptions _assetsOptions;
+        private readonly RhetosAppEnvironment _rhetosAppEnvironment;
 
         public IEnumerable<string> Dependencies => new List<string>();
 
-        public DataMigrationScriptsFile(AssetsOptions assetsOptions, ILogProvider logProvider)
+        public DataMigrationScriptsFile(RhetosAppEnvironment rhetosAppEnvironment, ILogProvider logProvider)
         {
             _performanceLogger = logProvider.GetLogger("Performance");
-            _assetsOptions = assetsOptions;
+            _rhetosAppEnvironment = rhetosAppEnvironment;
         }
 
         /// <summary>
@@ -65,6 +65,6 @@ namespace Rhetos.Deployment
             _performanceLogger.Write(stopwatch, $@"DataMigrationScriptsFromDisk: Saved {dataMigrationScripts.Scripts.Count} scripts to generated file.");
         }
 
-        private string DataMigrationScriptsFilePath => Path.Combine(_assetsOptions.AssetsFolder, DataMigrationScriptsFileName);
+        private string DataMigrationScriptsFilePath => Path.Combine(_rhetosAppEnvironment.AssetsFolder, DataMigrationScriptsFileName);
     }
 }

--- a/Source/Rhetos.Deployment/InstalledPackagesGenerator.cs
+++ b/Source/Rhetos.Deployment/InstalledPackagesGenerator.cs
@@ -30,9 +30,9 @@ namespace Rhetos.Deployment
         private readonly InstalledPackagesProvider _installedPackagesProvider;
         private readonly InstalledPackages _installedPackages;
 
-        public InstalledPackagesGenerator(InstalledPackages installedPackages, ILogProvider logProvider, AssetsOptions assetsOptions)
+        public InstalledPackagesGenerator(InstalledPackages installedPackages, ILogProvider logProvider, RhetosAppEnvironment rhetosAppEnvironment)
         {
-            _installedPackagesProvider = new InstalledPackagesProvider(logProvider, assetsOptions);
+            _installedPackagesProvider = new InstalledPackagesProvider(logProvider, rhetosAppEnvironment);
             _installedPackages = installedPackages;
         }
 

--- a/Source/Rhetos.Deployment/InstalledPackagesProvider.cs
+++ b/Source/Rhetos.Deployment/InstalledPackagesProvider.cs
@@ -30,10 +30,10 @@ namespace Rhetos.Deployment
         private readonly ILogger _logger;
         private readonly string _packagesFilePath;
 
-        public InstalledPackagesProvider(ILogProvider logProvider, AssetsOptions assetsOptions)
+        public InstalledPackagesProvider(ILogProvider logProvider, RhetosAppEnvironment rhetosAppEnvironment)
         {
             _logger = logProvider.GetLogger(GetType().Name);
-            _packagesFilePath = Path.Combine(assetsOptions.AssetsFolder, PackagesFileName);
+            _packagesFilePath = Path.Combine(rhetosAppEnvironment.AssetsFolder, PackagesFileName);
         }
 
         private const string PackagesFileName = "InstalledPackages.json";

--- a/Source/Rhetos.Deployment/Rhetos.Deployment.csproj
+++ b/Source/Rhetos.Deployment/Rhetos.Deployment.csproj
@@ -96,6 +96,7 @@
     <Compile Include="..\Rhetos\Properties\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="RhetosAppEnvironmentGenerator.cs" />
     <Compile Include="Sql.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Rhetos.Deployment/RhetosAppEnvironmentGenerator.cs
+++ b/Source/Rhetos.Deployment/RhetosAppEnvironmentGenerator.cs
@@ -1,0 +1,44 @@
+﻿/*
+    Copyright (C) 2014 Omega software d.o.o.
+
+    This file is part of Rhetos.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using Rhetos.Extensibility;
+using Rhetos.Utilities;
+using Rhetos.Utilities.ApplicationConfiguration;
+using System;
+using System.Collections.Generic;
+
+namespace Rhetos.Deployment
+{
+    public class RhetosAppEnvironmentGenerator : IGenerator
+    {
+        private readonly RhetosAppEnvironment _rhetosAppEnvironment;
+
+        public RhetosAppEnvironmentGenerator(RhetosAppEnvironment rhetosAppEnvironment)
+        {
+            _rhetosAppEnvironment = rhetosAppEnvironment;
+        }
+
+        public void Generate()
+        {
+            RhetosAppEnvironmentProvider.Save(_rhetosAppEnvironment);
+        }
+
+        public IEnumerable<string> Dependencies => Array.Empty<string>();
+    }
+}

--- a/Source/Rhetos.Dsl/DslModelFile.cs
+++ b/Source/Rhetos.Dsl/DslModelFile.cs
@@ -32,16 +32,16 @@ namespace Rhetos.Dsl
     {
         private readonly ILogger _performanceLogger;
         private readonly DslContainer _dslContainer;
-        private readonly AssetsOptions _assetsOptions;
+        private readonly RhetosAppEnvironment _rhetosAppEnvironment;
 
         public DslModelFile(
             ILogProvider logProvider,
             DslContainer dslContainer,
-            AssetsOptions assetsOptions)
+            RhetosAppEnvironment rhetosAppEnvironment)
         {
             _performanceLogger = logProvider.GetLogger("Performance");
             _dslContainer = dslContainer;
-            _assetsOptions = assetsOptions;
+            _rhetosAppEnvironment = rhetosAppEnvironment;
         }
 
         #region IDslModel implementation
@@ -115,7 +115,7 @@ namespace Rhetos.Dsl
             _performanceLogger.Write(sw, "DslModelFile.SaveConcepts: Write.");
         }
 
-        private string DslModelFilePath => Path.Combine(_assetsOptions.AssetsFolder, DslModelFileName);
+        private string DslModelFilePath => Path.Combine(_rhetosAppEnvironment.AssetsFolder, DslModelFileName);
 
         private IEnumerable<IConceptInfo> LoadConcepts()
         {

--- a/Source/Rhetos.Extensibility.Test/PluginScannerTest.cs
+++ b/Source/Rhetos.Extensibility.Test/PluginScannerTest.cs
@@ -37,7 +37,7 @@ namespace Rhetos.Extensibility.Test
         public void AnalyzeAndReportTypeLoadException()
         {
             IEnumerable<string> findAssemblies() => new[] { GetIncompatibleAssemblyPath() };
-            var pluginsScanner = new PluginScanner(findAssemblies, null, new AssetsOptions { AssetsFolder = "." }, new ConsoleLogProvider());
+            var pluginsScanner = new PluginScanner(findAssemblies, null, new RhetosAppEnvironment { AssetsFolder = "." }, new ConsoleLogProvider());
 
             TestUtility.ShouldFail<FrameworkException>(
                 () => pluginsScanner.FindPlugins(typeof(IGenerator)),

--- a/Source/Rhetos.Extensibility/PluginScanner.cs
+++ b/Source/Rhetos.Extensibility/PluginScanner.cs
@@ -45,12 +45,12 @@ namespace Rhetos.Extensibility
         /// It searches for type implementations in the provided list of assemblies.
         /// </summary>
         /// <param name="findAssemblies">The findAssemblies function should return a list of DLL file paths that will be searched for plugins when invoking the method <see cref="PluginScanner.FindPlugins"/></param>
-        public PluginScanner(Func<IEnumerable<string>> findAssemblies, BuildOptions buildOptions, AssetsOptions assetsOptions, ILogProvider logProvider)
+        public PluginScanner(Func<IEnumerable<string>> findAssemblies, BuildOptions buildOptions, RhetosAppEnvironment rhetosAppEnvironment, ILogProvider logProvider)
         {
             _pluginsByExport = new Lazy<MultiDictionary<string, PluginInfo>>(
                 () => GetPluginsByExport(findAssemblies),
                 LazyThreadSafetyMode.ExecutionAndPublication);
-            _pluginScannerCache = new PluginScannerCache(buildOptions, assetsOptions, logProvider, new FilesUtility(logProvider));
+            _pluginScannerCache = new PluginScannerCache(buildOptions, rhetosAppEnvironment, logProvider, new FilesUtility(logProvider));
             _performanceLogger = logProvider.GetLogger("Performance");
             _logger = logProvider.GetLogger(GetType().Name);
         }

--- a/Source/Rhetos.Extensibility/PluginScannerCache.cs
+++ b/Source/Rhetos.Extensibility/PluginScannerCache.cs
@@ -36,12 +36,12 @@ namespace Rhetos.Extensibility
         private readonly string _runtimeCacheFilePath;
         private readonly FilesUtility _filesUtility;
 
-        public PluginScannerCache(BuildOptions buildOptions, AssetsOptions assetsOptions, ILogProvider logProvider, FilesUtility filesUtility)
+        public PluginScannerCache(BuildOptions buildOptions, RhetosAppEnvironment rhetosAppEnvironment, ILogProvider logProvider, FilesUtility filesUtility)
         {
             _logger = logProvider.GetLogger(GetType().Name);
             if (buildOptions?.CacheFolder != null)
                 _buildCacheFilePath = Path.Combine(buildOptions.CacheFolder, _pluginScannerBuildCacheFilename);
-            _runtimeCacheFilePath = Path.Combine(assetsOptions.AssetsFolder, _pluginScannerRuntimeCacheFilename);
+            _runtimeCacheFilePath = Path.Combine(rhetosAppEnvironment.AssetsFolder, _pluginScannerRuntimeCacheFilename);
             _filesUtility = filesUtility;
         }
 

--- a/Source/Rhetos.Extensibility/PluginScannerCache.cs
+++ b/Source/Rhetos.Extensibility/PluginScannerCache.cs
@@ -28,7 +28,8 @@ namespace Rhetos.Extensibility
 {
     public class PluginScannerCache : IGenerator
     {
-        private const string _pluginScannerCacheFilename = "PluginScanner.Cache.json";
+        private const string _pluginScannerBuildCacheFilename = "PluginScanner.BuildCache.json";
+        private const string _pluginScannerRuntimeCacheFilename = "PluginScanner.RuntimeCache.json";
 
         private readonly ILogger _logger;
         private readonly string _buildCacheFilePath;
@@ -39,8 +40,8 @@ namespace Rhetos.Extensibility
         {
             _logger = logProvider.GetLogger(GetType().Name);
             if (buildOptions?.CacheFolder != null)
-                _buildCacheFilePath = Path.Combine(buildOptions.CacheFolder, _pluginScannerCacheFilename);
-            _runtimeCacheFilePath = Path.Combine(assetsOptions.AssetsFolder, _pluginScannerCacheFilename);
+                _buildCacheFilePath = Path.Combine(buildOptions.CacheFolder, _pluginScannerBuildCacheFilename);
+            _runtimeCacheFilePath = Path.Combine(assetsOptions.AssetsFolder, _pluginScannerRuntimeCacheFilename);
             _filesUtility = filesUtility;
         }
 
@@ -66,7 +67,7 @@ namespace Rhetos.Extensibility
             }
             else
             {
-                _logger.Trace($"Cache file '{_pluginScannerCacheFilename}' not found.");
+                _logger.Trace($"Cache file not found.");
                 return new PluginsCacheData();
             }
         }
@@ -81,9 +82,12 @@ namespace Rhetos.Extensibility
 
         private string GetExistingCacheFile()
         {
-            return File.Exists(_runtimeCacheFilePath) ? _runtimeCacheFilePath
-                : File.Exists(_buildCacheFilePath) ? _buildCacheFilePath
-                : null;
+            if (File.Exists(_runtimeCacheFilePath))
+                return _runtimeCacheFilePath;
+            else if (File.Exists(_buildCacheFilePath))
+                return _buildCacheFilePath;
+            else
+                return null;
         }
     }
 }

--- a/Source/Rhetos.Extensibility/PluginScannerCache.cs
+++ b/Source/Rhetos.Extensibility/PluginScannerCache.cs
@@ -77,6 +77,7 @@ namespace Rhetos.Extensibility
             string cacheFilePath = GetExistingCacheFile() ?? _buildCacheFilePath ?? _runtimeCacheFilePath;
 
             _logger.Trace($"Writing cache to '{cacheFilePath}'.");
+            _filesUtility.SafeCreateDirectory(Path.GetDirectoryName(cacheFilePath)); // Plugin scanner can be executed before other Rhetos components are initialized.
             File.WriteAllText(cacheFilePath, JsonConvert.SerializeObject(cache, Formatting.Indented));
         }
 

--- a/Source/Rhetos.Persistence.Test/MsSqlExecuterTest.cs
+++ b/Source/Rhetos.Persistence.Test/MsSqlExecuterTest.cs
@@ -55,7 +55,6 @@ namespace Rhetos.Persistence.Test
         public void ChecklDatabaseAvailability()
         {
             var configurationProvider = new ConfigurationBuilder()
-                .AddRhetosAppConfiguration(AppDomain.CurrentDomain.BaseDirectory)
                 .AddConfigurationManagerConfiguration()
                 .Build();
             LegacyUtilities.Initialize(configurationProvider);

--- a/Source/Rhetos.Persistence/EntityFrameworkMappingGenerator.cs
+++ b/Source/Rhetos.Persistence/EntityFrameworkMappingGenerator.cs
@@ -48,18 +48,18 @@ namespace Rhetos.Persistence
         private readonly ICodeGenerator _codeGenerator;
         private readonly IPluginsContainer<IConceptMapping> _plugins;
         private readonly ILogger _performanceLogger;
-        private readonly AssetsOptions _assetsOptions;
+        private readonly RhetosAppEnvironment _rhetosAppEnvironment;
 
         public EntityFrameworkMappingGenerator(
             ICodeGenerator codeGenerator,
             IPluginsContainer<IConceptMapping> plugins,
-            AssetsOptions assetsOptions,
+            RhetosAppEnvironment rhetosAppEnvironment,
             ILogProvider logProvider)
         {
             _plugins = plugins;
             _codeGenerator = codeGenerator;
             _performanceLogger = logProvider.GetLogger("Performance");
-            _assetsOptions = assetsOptions;
+            _rhetosAppEnvironment = rhetosAppEnvironment;
         }
 
         public void Generate()
@@ -75,7 +75,7 @@ namespace Rhetos.Persistence
             for (int s = 0; s < segments.Count(); s++)
             {
                 string clearedXml = XmlUtility.RemoveComments(segments[s]);
-                string filePath = Path.Combine(_assetsOptions.AssetsFolder, EntityFrameworkMapping.ModelFiles[s]);
+                string filePath = Path.Combine(_rhetosAppEnvironment.AssetsFolder, EntityFrameworkMapping.ModelFiles[s]);
                 File.WriteAllText(filePath, clearedXml, Encoding.UTF8);
             }
 

--- a/Source/Rhetos.Utilities.Test/ConfigurationProviderTests.cs
+++ b/Source/Rhetos.Utilities.Test/ConfigurationProviderTests.cs
@@ -310,7 +310,7 @@ namespace Rhetos.Utilities.Test
             var rootPath = AppDomain.CurrentDomain.BaseDirectory;
             System.Diagnostics.Trace.WriteLine($"Using {rootPath} as rootPath.");
             var provider = new ConfigurationBuilder()
-                .AddRhetosAppConfiguration(rootPath)
+                .AddWebConfiguration(rootPath)
                 .Build();
 
             Assert.IsTrue(provider.AllKeys.Contains("ConnectionStrings:WebConnectionString:Name"));

--- a/Source/Rhetos.Utilities.Test/LegacyUtilitiesTests.cs
+++ b/Source/Rhetos.Utilities.Test/LegacyUtilitiesTests.cs
@@ -18,13 +18,8 @@
 */
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Rhetos.Extensibility;
 using Rhetos.TestCommon;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
 
 namespace Rhetos.Utilities.Test
 {
@@ -52,18 +47,15 @@ namespace Rhetos.Utilities.Test
         [TestMethod]
         public void PathThrowsOnNullEnvironment()
         {
-            Paths.Initialize(null, null, null);
+            Paths.Initialize(null);
             TestUtility.ShouldFail<FrameworkException>(() => Console.WriteLine(Paths.RhetosServerRootPath), "Rhetos server is not initialized (Paths class)");
             TestUtility.ShouldFail<FrameworkException>(() => Console.WriteLine(Paths.BinFolder), "Rhetos server is not initialized (Paths class)");
             TestUtility.ShouldFail<FrameworkException>(() => Console.WriteLine(Paths.GeneratedFolder), "Rhetos server is not initialized (Paths class)");
             TestUtility.ShouldFail<FrameworkException>(() => Console.WriteLine(Paths.PluginsFolder), "Rhetos server is not initialized (Paths class)");
             TestUtility.ShouldFail<FrameworkException>(() => Console.WriteLine(Paths.ResourcesFolder), "Rhetos server is not initialized (Paths class)");
 
-            Paths.Initialize(null, new RhetosAppOptions(), null);
-            TestUtility.ShouldFail<FrameworkException>(() => Console.WriteLine(Paths.GeneratedFolder), "Rhetos server is not initialized (Paths class)");
-
-            Paths.Initialize(null, null, new AssetsOptions());
-            TestUtility.ShouldFail<FrameworkException>(() => Console.WriteLine(Paths.GeneratedFolder), "AssetsFolder expected to be configured");
+            Paths.Initialize(new RhetosAppEnvironment());
+            TestUtility.ShouldFail<FrameworkException>(() => Console.WriteLine(Paths.GeneratedFolder), "'AssetsFolder' is expected to be configured");
         }
     }
 }

--- a/Source/Rhetos.Utilities.Test/LegacyUtilitiesTests.cs
+++ b/Source/Rhetos.Utilities.Test/LegacyUtilitiesTests.cs
@@ -29,7 +29,6 @@ namespace Rhetos.Utilities.Test
         public LegacyUtilitiesTests()
         {
             var configurationProvider = new ConfigurationBuilder()
-                .AddRhetosAppConfiguration(AppDomain.CurrentDomain.BaseDirectory)
                 .AddConfigurationManagerConfiguration()
                 .Build();
 

--- a/Source/Rhetos.Utilities.Test/SqlUtilityTest.cs
+++ b/Source/Rhetos.Utilities.Test/SqlUtilityTest.cs
@@ -33,7 +33,6 @@ namespace Rhetos.Utilities.Test
         public SqlUtilityTest()
         {
             var configurationProvider = new ConfigurationBuilder()
-                .AddRhetosAppConfiguration(AppDomain.CurrentDomain.BaseDirectory)
                 .AddConfigurationManagerConfiguration()
                 .Build();
 

--- a/Source/Rhetos.Utilities/ApplicationConfiguration/ConfigurationSources/ConfigurationSourcesBuilderExtensions.cs
+++ b/Source/Rhetos.Utilities/ApplicationConfiguration/ConfigurationSources/ConfigurationSourcesBuilderExtensions.cs
@@ -89,14 +89,14 @@ namespace Rhetos
             if (oldBuildProcess)
             {
                 // Legacy build process with DeployPackage
-                builder.AddKeyValue(nameof(AssetsOptions.AssetsFolder), Path.Combine(rhetosAppRootPath, "bin\\Generated"));
-                builder.AddKeyValue(nameof(RhetosAppOptions.BinFolder), Path.Combine(rhetosAppRootPath, "bin"));
+                builder.AddKeyValue(nameof(RhetosAppEnvironment.AssetsFolder), Path.Combine(rhetosAppRootPath, "bin\\Generated"));
+                builder.AddKeyValue(nameof(RhetosAppEnvironment.BinFolder), Path.Combine(rhetosAppRootPath, "bin"));
             }
             else
             {
                 // New build process with Rhetos CLI
-                builder.AddKeyValue(nameof(AssetsOptions.AssetsFolder), Path.Combine(rhetosAppRootPath, "bin"));
-                builder.AddKeyValue(nameof(RhetosAppOptions.BinFolder), Path.Combine(rhetosAppRootPath, "bin"));
+                builder.AddKeyValue(nameof(RhetosAppEnvironment.AssetsFolder), Path.Combine(rhetosAppRootPath, "bin"));
+                builder.AddKeyValue(nameof(RhetosAppEnvironment.BinFolder), Path.Combine(rhetosAppRootPath, "bin"));
             }
 
             builder.AddKeyValue("RootPath", rhetosAppRootPath);

--- a/Source/Rhetos.Utilities/ApplicationConfiguration/ConfigurationSources/ConfigurationSourcesBuilderExtensions.cs
+++ b/Source/Rhetos.Utilities/ApplicationConfiguration/ConfigurationSources/ConfigurationSourcesBuilderExtensions.cs
@@ -18,13 +18,11 @@
 */
 
 using Rhetos.Utilities;
+using Rhetos.Utilities.ApplicationConfiguration;
 using Rhetos.Utilities.ApplicationConfiguration.ConfigurationSources;
-using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Web.Configuration;
 
 namespace Rhetos
@@ -82,26 +80,18 @@ namespace Rhetos
         /// </summary>
         public static IConfigurationBuilder AddRhetosAppConfiguration(this IConfigurationBuilder builder, string rhetosAppRootPath)
         {
-            rhetosAppRootPath = Path.GetFullPath(rhetosAppRootPath);
+            var rhetosAppEnvironment = RhetosAppEnvironmentProvider.Load(rhetosAppRootPath);
+            return builder
+                .AddRhetosAppEnvironment(rhetosAppEnvironment)
+                .AddWebConfiguration(rhetosAppRootPath);
+        }
 
-            // TODO: Remove this conditional settings after implementation of persisting build configuration for use in runtime.
-            bool oldBuildProcess = File.Exists(Path.Combine(rhetosAppRootPath, @"bin\DeployPackages.exe"));
-            if (oldBuildProcess)
-            {
-                // Legacy build process with DeployPackage
-                builder.AddKeyValue(nameof(RhetosAppEnvironment.AssetsFolder), Path.Combine(rhetosAppRootPath, "bin\\Generated"));
-                builder.AddKeyValue(nameof(RhetosAppEnvironment.BinFolder), Path.Combine(rhetosAppRootPath, "bin"));
-            }
-            else
-            {
-                // New build process with Rhetos CLI
-                builder.AddKeyValue(nameof(RhetosAppEnvironment.AssetsFolder), Path.Combine(rhetosAppRootPath, "bin"));
-                builder.AddKeyValue(nameof(RhetosAppEnvironment.BinFolder), Path.Combine(rhetosAppRootPath, "bin"));
-            }
-
-            builder.AddKeyValue("RootPath", rhetosAppRootPath);
-            builder.AddWebConfiguration(rhetosAppRootPath);
-            return builder;
+        public static IConfigurationBuilder AddRhetosAppEnvironment(this IConfigurationBuilder builder, RhetosAppEnvironment rhetosAppEnvironment)
+        {
+            return builder
+                .AddKeyValue(nameof(RhetosAppEnvironment.RootPath), rhetosAppEnvironment.RootPath)
+                .AddKeyValue(nameof(RhetosAppEnvironment.BinFolder), rhetosAppEnvironment.BinFolder)
+                .AddKeyValue(nameof(RhetosAppEnvironment.AssetsFolder), rhetosAppEnvironment.AssetsFolder);
         }
 
         /// <summary>

--- a/Source/Rhetos.Utilities/ApplicationConfiguration/ConfigurationSources/ConfigurationSourcesBuilderExtensions.cs
+++ b/Source/Rhetos.Utilities/ApplicationConfiguration/ConfigurationSources/ConfigurationSourcesBuilderExtensions.cs
@@ -91,7 +91,9 @@ namespace Rhetos
             return builder
                 .AddKeyValue(nameof(RhetosAppEnvironment.RootPath), rhetosAppEnvironment.RootPath)
                 .AddKeyValue(nameof(RhetosAppEnvironment.BinFolder), rhetosAppEnvironment.BinFolder)
-                .AddKeyValue(nameof(RhetosAppEnvironment.AssetsFolder), rhetosAppEnvironment.AssetsFolder);
+                .AddKeyValue(nameof(RhetosAppEnvironment.AssetsFolder), rhetosAppEnvironment.AssetsFolder)
+                .AddKeyValue(nameof(RhetosAppEnvironment.LegacyPluginsFolder), rhetosAppEnvironment.LegacyPluginsFolder)
+                .AddKeyValue(nameof(RhetosAppEnvironment.LegacyAssetsFolder), rhetosAppEnvironment.LegacyAssetsFolder);
         }
 
         /// <summary>

--- a/Source/Rhetos.Utilities/ApplicationConfiguration/RhetosAppEnvironmentProvider.cs
+++ b/Source/Rhetos.Utilities/ApplicationConfiguration/RhetosAppEnvironmentProvider.cs
@@ -1,0 +1,69 @@
+﻿/*
+    Copyright (C) 2014 Omega software d.o.o.
+
+    This file is part of Rhetos.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Rhetos.Utilities.ApplicationConfiguration
+{
+    public static class RhetosAppEnvironmentProvider
+    {
+        private const string RhetosAppEnvironmentFileName = "RhetosAppEnvironment.json";
+
+        public static void Save(RhetosAppEnvironment rhetosAppEnvironment)
+        {
+            string saveFolder = rhetosAppEnvironment.AssetsFolder;
+            var relativePaths = new Dictionary<string, string>
+            {
+                { nameof(RhetosAppEnvironment.RootPath), FilesUtility.AbsoluteToRelativePath(saveFolder, rhetosAppEnvironment.RootPath) },
+                { nameof(RhetosAppEnvironment.BinFolder), FilesUtility.AbsoluteToRelativePath(saveFolder, rhetosAppEnvironment.BinFolder) },
+                { nameof(RhetosAppEnvironment.AssetsFolder), FilesUtility.AbsoluteToRelativePath(saveFolder, rhetosAppEnvironment.AssetsFolder) },
+            };
+
+            string serialized = JsonConvert.SerializeObject(relativePaths, Formatting.Indented);
+            string filePath = Path.Combine(saveFolder, RhetosAppEnvironmentFileName);
+            File.WriteAllText(filePath, serialized, Encoding.UTF8);
+        }
+
+        public static RhetosAppEnvironment Load(string rhetosAppRootPath)
+        {
+            rhetosAppRootPath = Path.GetFullPath(rhetosAppRootPath); // For better error reporting.
+
+            var filePaths = Directory.GetFiles(rhetosAppRootPath, RhetosAppEnvironmentFileName, SearchOption.AllDirectories);
+            if (!filePaths.Any())
+                throw new FrameworkException($"Missing file '{RhetosAppEnvironmentFileName}' in folder '{rhetosAppRootPath}' or subfolders.");
+            if (filePaths.Length >= 2)
+                throw new FrameworkException($"Multiple '{RhetosAppEnvironmentFileName}' files found: {string.Join(", ", filePaths)}.");
+
+            var serialized = File.ReadAllText(filePaths.Single(), Encoding.UTF8);
+            var relativePaths = JsonConvert.DeserializeObject<Dictionary<string, string>>(serialized);
+
+            string saveFolder = Path.GetDirectoryName(filePaths.Single());
+            return new RhetosAppEnvironment
+            {
+                RootPath = rhetosAppRootPath, // This is not inherited from build-time. Project folder at build could be different then output application folder.
+                BinFolder = FilesUtility.RelativeToAbsolutePath(saveFolder, relativePaths[nameof(RhetosAppEnvironment.BinFolder)]),
+                AssetsFolder = FilesUtility.RelativeToAbsolutePath(saveFolder, relativePaths[nameof(RhetosAppEnvironment.AssetsFolder)]),
+            };
+        }
+    }
+}

--- a/Source/Rhetos.Utilities/ApplicationConfiguration/RhetosAppEnvironmentProvider.cs
+++ b/Source/Rhetos.Utilities/ApplicationConfiguration/RhetosAppEnvironmentProvider.cs
@@ -37,6 +37,8 @@ namespace Rhetos.Utilities.ApplicationConfiguration
                 { nameof(RhetosAppEnvironment.RootPath), FilesUtility.AbsoluteToRelativePath(saveFolder, rhetosAppEnvironment.RootPath) },
                 { nameof(RhetosAppEnvironment.BinFolder), FilesUtility.AbsoluteToRelativePath(saveFolder, rhetosAppEnvironment.BinFolder) },
                 { nameof(RhetosAppEnvironment.AssetsFolder), FilesUtility.AbsoluteToRelativePath(saveFolder, rhetosAppEnvironment.AssetsFolder) },
+                { nameof(RhetosAppEnvironment.LegacyPluginsFolder), FilesUtility.AbsoluteToRelativePath(saveFolder, rhetosAppEnvironment.LegacyPluginsFolder) },
+                { nameof(RhetosAppEnvironment.LegacyAssetsFolder), FilesUtility.AbsoluteToRelativePath(saveFolder, rhetosAppEnvironment.LegacyAssetsFolder) },
             };
 
             string serialized = JsonConvert.SerializeObject(relativePaths, Formatting.Indented);
@@ -64,6 +66,8 @@ namespace Rhetos.Utilities.ApplicationConfiguration
                 RootPath = rhetosAppRootPath, // This is not inherited from build-time. Project folder at build could be different then output application folder.
                 BinFolder = FilesUtility.RelativeToAbsolutePath(saveFolder, relativePaths[nameof(RhetosAppEnvironment.BinFolder)]),
                 AssetsFolder = FilesUtility.RelativeToAbsolutePath(saveFolder, relativePaths[nameof(RhetosAppEnvironment.AssetsFolder)]),
+                LegacyPluginsFolder = FilesUtility.RelativeToAbsolutePath(saveFolder, relativePaths[nameof(RhetosAppEnvironment.LegacyPluginsFolder)]),
+                LegacyAssetsFolder = FilesUtility.RelativeToAbsolutePath(saveFolder, relativePaths[nameof(RhetosAppEnvironment.LegacyAssetsFolder)]),
             };
         }
     }

--- a/Source/Rhetos.Utilities/ApplicationConfiguration/RhetosAppEnvironmentProvider.cs
+++ b/Source/Rhetos.Utilities/ApplicationConfiguration/RhetosAppEnvironmentProvider.cs
@@ -50,7 +50,8 @@ namespace Rhetos.Utilities.ApplicationConfiguration
 
             var filePaths = Directory.GetFiles(rhetosAppRootPath, RhetosAppEnvironmentFileName, SearchOption.AllDirectories);
             if (!filePaths.Any())
-                throw new FrameworkException($"Missing file '{RhetosAppEnvironmentFileName}' in folder '{rhetosAppRootPath}' or subfolders.");
+                throw new FrameworkException($"Missing file '{RhetosAppEnvironmentFileName}' in folder '{rhetosAppRootPath}' or subfolders." +
+                    $" Please verify that the specified folder contains a valid Rhetos application, and that the build have passed successfully.");
             if (filePaths.Length >= 2)
                 throw new FrameworkException($"Multiple '{RhetosAppEnvironmentFileName}' files found: {string.Join(", ", filePaths)}.");
 

--- a/Source/Rhetos.Utilities/DatabaseOptions.cs
+++ b/Source/Rhetos.Utilities/DatabaseOptions.cs
@@ -19,6 +19,9 @@
 
 namespace Rhetos.Utilities
 {
+    /// <summary>
+    /// Runtime options, to be used when connecting to a database.
+    /// </summary>
     public class DatabaseOptions
     {
         public int SqlCommandTimeout { get; set; } = 30;

--- a/Source/Rhetos.Utilities/Legacy/Configuration.cs
+++ b/Source/Rhetos.Utilities/Legacy/Configuration.cs
@@ -28,30 +28,43 @@ namespace Rhetos.Utilities
     public class Configuration : IConfiguration
     {
         private readonly IConfigurationProvider _configurationProvider;
+        private static IConfigurationProvider _staticConfigurationProvider;
+        private IConfigurationProvider AnyConfigurationProvider => _configurationProvider ?? _staticConfigurationProvider;
+
+        internal static void Initialize(IConfigurationProvider configurationProvider)
+        {
+            _staticConfigurationProvider = configurationProvider;
+        }
+
+        public Configuration()
+        {
+            // Legacy constructor, _staticConfigurationProvider will be used.
+        }
 
         public Configuration(IConfigurationProvider configurationProvider)
         {
             _configurationProvider = configurationProvider;
         }
+        
 
         public Lazy<string> GetString(string key, string defaultValue)
         {
-            return new Lazy<string>(() => _configurationProvider.GetValue(key, defaultValue));
+            return new Lazy<string>(() => AnyConfigurationProvider.GetValue(key, defaultValue));
         }
 
         public Lazy<int> GetInt(string key, int defaultValue)
         {
-            return new Lazy<int>(() => _configurationProvider.GetValue<int>(key, defaultValue));
+            return new Lazy<int>(() => AnyConfigurationProvider.GetValue(key, defaultValue));
         }
 
         public Lazy<bool> GetBool(string key, bool defaultValue)
         {
-            return new Lazy<bool>(() => _configurationProvider.GetValue(key, defaultValue));
+            return new Lazy<bool>(() => AnyConfigurationProvider.GetValue(key, defaultValue));
         }
 
         public Lazy<T> GetEnum<T>(string key, T defaultValue) where T : struct
         {
-            return new Lazy<T>(() => _configurationProvider.GetValue(key, defaultValue));
+            return new Lazy<T>(() => AnyConfigurationProvider.GetValue(key, defaultValue));
         }
     }
 }

--- a/Source/Rhetos.Utilities/Legacy/LegacyUtilities.cs
+++ b/Source/Rhetos.Utilities/Legacy/LegacyUtilities.cs
@@ -33,9 +33,7 @@ namespace Rhetos
         /// </summary>
         public static void Initialize(IConfigurationProvider configurationProvider)
         {
-            var rhetosAppOptions = configurationProvider.GetOptions<RhetosAppOptions>();
-            var assetsOptions = configurationProvider.GetOptions<AssetsOptions>();
-            Paths.Initialize(configurationProvider.GetValue<string>("RootPath"), rhetosAppOptions, assetsOptions);
+            Paths.Initialize(configurationProvider.GetOptions<RhetosAppEnvironment>());
             ConfigUtility.Initialize(configurationProvider);
             SqlUtility.Initialize(configurationProvider);
         }

--- a/Source/Rhetos.Utilities/Legacy/LegacyUtilities.cs
+++ b/Source/Rhetos.Utilities/Legacy/LegacyUtilities.cs
@@ -28,7 +28,7 @@ namespace Rhetos
     {
 #pragma warning disable CS0618 // Type or member is obsolete
         /// <summary>
-        /// Use to initialize obsolete static utilities <see cref="Paths"/>, <see cref="ConfigUtility"/> and <see cref="SqlUtility"/> 
+        /// Use to initialize obsolete static utilities <see cref="Paths"/>, <see cref="ConfigUtility"/>, <see cref="Configuration"/> and <see cref="SqlUtility"/> 
         /// prior to using any of their methods. This will bind those utilities to configuration source compliant with new configuration convention.
         /// </summary>
         public static void Initialize(IConfigurationProvider configurationProvider)
@@ -36,17 +36,20 @@ namespace Rhetos
             Paths.Initialize(configurationProvider.GetOptions<RhetosAppEnvironment>());
             ConfigUtility.Initialize(configurationProvider);
             SqlUtility.Initialize(configurationProvider);
+            Configuration.Initialize(configurationProvider);
         }
 
         /// <summary>
         /// Returns list of assemblies that will be scanned for plugin exports.
         /// </summary>
-        public static Func<List<string>> GetListAssembliesDelegate()
+        public static Func<List<string>> GetListAssembliesDelegate(IConfigurationProvider configurationProvider)
         {
+            var rhetosAppEnvironment = configurationProvider.GetOptions<RhetosAppEnvironment>();
+
             return () =>
             {
                 // Rhetos framework does not contain plugins exports (only explicit registration), so only plugins and generated files need to be scanned for plugins.
-                string[] pluginsPath = new[] { Paths.PluginsFolder, Paths.GeneratedFolder };
+                string[] pluginsPath = new[] { rhetosAppEnvironment.LegacyPluginsFolder, rhetosAppEnvironment.AssetsFolder };
 
                 List<string> assemblies = new List<string>();
                 foreach (var path in pluginsPath)

--- a/Source/Rhetos.Utilities/Legacy/Paths.cs
+++ b/Source/Rhetos.Utilities/Legacy/Paths.cs
@@ -38,35 +38,27 @@ namespace Rhetos.Utilities
             _rhetosAppEnvironment = rhetosAppEnvironment;
         }
 
-        public static string RhetosServerRootPath => SafeGetRootPath();
-        public static string ResourcesFolder => Path.Combine(SafeGetRootPath(), "Resources");
-        public static string BinFolder => SafeGetBinFolder();
-        public static string GeneratedFolder => SafeGetAssetsFolder();
-        public static string PluginsFolder => Path.Combine(SafeGetBinFolder(), "Plugins");
-        public static string GetDomAssemblyFile(DomAssemblies domAssembly) => Path.Combine(SafeGetAssetsFolder(), $"ServerDom.{domAssembly}.dll");
+        public static string RhetosServerRootPath => SafeGetAppEnvironment().RootPath
+                ?? throw new FrameworkException($"'{nameof(RhetosAppEnvironment.RootPath)}' is expected to be configured with valid value, but is empty.");
+
+        public static string ResourcesFolder => SafeGetAppEnvironment().LegacyAssetsFolder
+                ?? throw new FrameworkException($"'{nameof(RhetosAppEnvironment.LegacyAssetsFolder)}' is expected to be configured with valid value, but is empty.");
+
+        public static string BinFolder => SafeGetAppEnvironment().BinFolder
+                ?? throw new FrameworkException($"'{nameof(RhetosAppEnvironment.BinFolder)}' is expected to be configured with valid value, but is empty.");
+
+        public static string GeneratedFolder => SafeGetAppEnvironment().AssetsFolder
+                ?? throw new FrameworkException($"'{nameof(RhetosAppEnvironment.AssetsFolder)}' is expected to be configured with valid value, but is empty.");
+
+        public static string PluginsFolder => SafeGetAppEnvironment().LegacyPluginsFolder
+                ?? throw new FrameworkException($"'{nameof(RhetosAppEnvironment.LegacyPluginsFolder)}' is expected to be configured with valid value, but is empty.");
+
+        public static string GetDomAssemblyFile(DomAssemblies domAssembly) => Path.Combine(GeneratedFolder, $"ServerDom.{domAssembly}.dll");
 
         /// <summary>
         /// List of the generated DLL files that make the domain object model (ServerDom.*.dll).
         /// </summary>
         public static IEnumerable<string> DomAssemblyFiles => Enum.GetValues(typeof(DomAssemblies)).Cast<DomAssemblies>().Select(domAssembly => GetDomAssemblyFile(domAssembly));
-
-        private static string SafeGetRootPath()
-        {
-            return SafeGetAppEnvironment().RootPath
-                ?? throw new FrameworkException($"'{nameof(RhetosAppEnvironment.RootPath)}' is expected to be configured with valid value, but is empty.");
-        }
-
-        private static string SafeGetBinFolder()
-        {
-            return SafeGetAppEnvironment().BinFolder
-                ?? throw new FrameworkException($"'{nameof(RhetosAppEnvironment.BinFolder)}' is expected to be configured with valid value, but is empty.");
-        }
-
-        private static string SafeGetAssetsFolder()
-        {
-            return SafeGetAppEnvironment().AssetsFolder
-                ?? throw new FrameworkException($"'{nameof(RhetosAppEnvironment.AssetsFolder)}' is expected to be configured with valid value, but is empty.");
-        }
 
         private static RhetosAppEnvironment SafeGetAppEnvironment()
         {

--- a/Source/Rhetos.Utilities/Legacy/Paths.cs
+++ b/Source/Rhetos.Utilities/Legacy/Paths.cs
@@ -22,80 +22,57 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 
 namespace Rhetos.Utilities
 {
-    [Obsolete("Use RhetosAppOptions or BuildOptions instead.")]
+    [Obsolete("Use RhetosAppEnvironment instead.")]
     public static class Paths
     {
-        private static string _rootPath;
-        private static RhetosAppOptions _appOptions;
-        private static AssetsOptions _assetsOptions;
+        private static RhetosAppEnvironment _rhetosAppEnvironment;
 
         /// <summary>
         /// Initialize Paths for the Rhetos server.
         /// </summary>
-        public static void Initialize(string rootPath, RhetosAppOptions appOptions, AssetsOptions assetsOptions)
+        public static void Initialize(RhetosAppEnvironment rhetosAppEnvironment)
         {
-            _rootPath = rootPath;
-            _appOptions = appOptions;
-            _assetsOptions = assetsOptions;
+            _rhetosAppEnvironment = rhetosAppEnvironment;
         }
 
-        public static string RhetosServerRootPath => NonNullRhetosRootPath;
-        public static string ResourcesFolder => Path.Combine(NonNullRhetosRootPath, "Resources");
-        public static string BinFolder => NonNullRhetosAppOptions.BinFolder;
-        public static string GeneratedFolder => NotNullGeneratedFolder;
-        public static string PluginsFolder => Path.Combine(NonNullRhetosRootPath, "bin\\Plugins");
-        public static string GetDomAssemblyFile(DomAssemblies domAssembly) => Path.Combine(NotNullGeneratedFolder, $"ServerDom.{domAssembly}.dll");
+        public static string RhetosServerRootPath => SafeGetRootPath();
+        public static string ResourcesFolder => Path.Combine(SafeGetRootPath(), "Resources");
+        public static string BinFolder => SafeGetBinFolder();
+        public static string GeneratedFolder => SafeGetAssetsFolder();
+        public static string PluginsFolder => Path.Combine(SafeGetBinFolder(), "Plugins");
+        public static string GetDomAssemblyFile(DomAssemblies domAssembly) => Path.Combine(SafeGetAssetsFolder(), $"ServerDom.{domAssembly}.dll");
+
         /// <summary>
-        /// List of the generated dll files that make the domain object model (ServerDom.*.dll).
+        /// List of the generated DLL files that make the domain object model (ServerDom.*.dll).
         /// </summary>
         public static IEnumerable<string> DomAssemblyFiles => Enum.GetValues(typeof(DomAssemblies)).Cast<DomAssemblies>().Select(domAssembly => GetDomAssemblyFile(domAssembly));
 
-        private static void AssertRhetosAppOptionsNotNull()
+        private static string SafeGetRootPath()
         {
-            if (_appOptions == null)
-                throw new FrameworkException($"Rhetos server is not initialized ({nameof(Paths)} class)." +
-                    $" Use {nameof(LegacyUtilities)}.{nameof(LegacyUtilities.Initialize)}() to initialize obsolete static utilities" +
-                    $" or use {nameof(RhetosAppOptions)}.");
+            return SafeGetAppEnvironment().RootPath
+                ?? throw new FrameworkException($"'{nameof(RhetosAppEnvironment.RootPath)}' is expected to be configured with valid value, but is empty.");
         }
 
-        private static RhetosAppOptions NonNullRhetosAppOptions
+        private static string SafeGetBinFolder()
         {
-            get
-            {
-                AssertRhetosAppOptionsNotNull();
-                return _appOptions;
-            }
+            return SafeGetAppEnvironment().BinFolder
+                ?? throw new FrameworkException($"'{nameof(RhetosAppEnvironment.BinFolder)}' is expected to be configured with valid value, but is empty.");
         }
 
-        private static string NonNullRhetosRootPath
+        private static string SafeGetAssetsFolder()
         {
-            get
-            {
-                if (_rootPath == null)
-                    throw new FrameworkException($"Rhetos server is not initialized ({nameof(Paths)} class)." +
-                        $" Use {nameof(LegacyUtilities)}.{nameof(LegacyUtilities.Initialize)}() to initialize obsolete static utilities");
-
-                return _rootPath;
-            }
+            return SafeGetAppEnvironment().AssetsFolder
+                ?? throw new FrameworkException($"'{nameof(RhetosAppEnvironment.AssetsFolder)}' is expected to be configured with valid value, but is empty.");
         }
 
-        private static string NotNullGeneratedFolder
+        private static RhetosAppEnvironment SafeGetAppEnvironment()
         {
-            get
-            {
-                if (_assetsOptions == null)
-                    throw new FrameworkException($"Rhetos server is not initialized ({nameof(Paths)} class)." +
-                        $" Use {nameof(LegacyUtilities)}.{nameof(LegacyUtilities.Initialize)}() to initialize obsolete static utilities");
-
-                if (string.IsNullOrEmpty(_assetsOptions.AssetsFolder))
-                    throw new FrameworkException($"{nameof(AssetsOptions.AssetsFolder)} expected to be configured with valid value, but is empty.");
-
-                return _assetsOptions.AssetsFolder;
-            }
+            return _rhetosAppEnvironment
+                ?? throw new FrameworkException($"Rhetos server is not initialized ({nameof(Paths)} class)." +
+                    $" Use {nameof(LegacyUtilities)}.{nameof(LegacyUtilities.Initialize)}() to initialize obsolete static utilities.");
         }
     }
 }

--- a/Source/Rhetos.Utilities/Rhetos.Utilities.csproj
+++ b/Source/Rhetos.Utilities/Rhetos.Utilities.csproj
@@ -150,7 +150,6 @@
     <Compile Include="ApplicationConfiguration\IConfigurationProvider.cs" />
     <Compile Include="ApplicationConfiguration\ConfigurationSources\IConfigurationSource.cs" />
     <Compile Include="ApplicationConfiguration\ConfigurationSources\KeyValuesSource.cs" />
-    <Compile Include="AssetsOptions.cs" />
     <Compile Include="BuildOptions.cs" />
     <Compile Include="Legacy\LegacyUtilities.cs" />
     <Compile Include="Legacy\Configuration.cs" />
@@ -164,6 +163,7 @@
     <Compile Include="ISqlUtility.cs" />
     <Compile Include="IUserInfoAdmin.cs" />
     <Compile Include="ListOfTuples.cs" />
+    <Compile Include="RhetosAppEnvironment.cs" />
     <Compile Include="RhetosAppOptions.cs" />
     <Compile Include="SecurityOptions.cs" />
     <Compile Include="DatabaseOptions.cs" />

--- a/Source/Rhetos.Utilities/Rhetos.Utilities.csproj
+++ b/Source/Rhetos.Utilities/Rhetos.Utilities.csproj
@@ -150,6 +150,7 @@
     <Compile Include="ApplicationConfiguration\IConfigurationProvider.cs" />
     <Compile Include="ApplicationConfiguration\ConfigurationSources\IConfigurationSource.cs" />
     <Compile Include="ApplicationConfiguration\ConfigurationSources\KeyValuesSource.cs" />
+    <Compile Include="ApplicationConfiguration\RhetosAppEnvironmentProvider.cs" />
     <Compile Include="BuildOptions.cs" />
     <Compile Include="Legacy\LegacyUtilities.cs" />
     <Compile Include="Legacy\Configuration.cs" />

--- a/Source/Rhetos.Utilities/RhetosAppEnvironment.cs
+++ b/Source/Rhetos.Utilities/RhetosAppEnvironment.cs
@@ -17,16 +17,21 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Rhetos.Utilities
 {
-    public class AssetsOptions
+    /// <summary>
+    /// Basic information about generated Rhetos application.
+    /// Configured and persisted at build-time. Available at run-time.
+    /// </summary>
+    public class RhetosAppEnvironment
     {
+        /// <summary>
+        /// Rhetos application's base folder.
+        /// </summary>
+        public string RootPath { get; set; }
+
         public string AssetsFolder { get; set; }
+
+        public string BinFolder { get; set; }
     }
 }

--- a/Source/Rhetos.Utilities/RhetosAppEnvironment.cs
+++ b/Source/Rhetos.Utilities/RhetosAppEnvironment.cs
@@ -30,8 +30,18 @@ namespace Rhetos.Utilities
         /// </summary>
         public string RootPath { get; set; }
 
+        public string BinFolder { get; set; }
+
         public string AssetsFolder { get; set; }
 
-        public string BinFolder { get; set; }
+        /// <summary>
+        /// This folder can be configured to support legacy plugins.
+        /// </summary>
+        public string LegacyPluginsFolder { get; set; }
+
+        /// <summary>
+        /// This folder can be configured to support legacy plugins by setting value to "Resources" subfolder inside the <see cref="RootPath"/>.
+        /// </summary>
+        public string LegacyAssetsFolder { get; set; }
     }
 }

--- a/Source/Rhetos.Utilities/RhetosAppOptions.cs
+++ b/Source/Rhetos.Utilities/RhetosAppOptions.cs
@@ -19,9 +19,11 @@
 
 namespace Rhetos.Utilities
 {
+    /// <summary>
+    /// Runtime configuration settings.
+    /// </summary>
     public class RhetosAppOptions
     {
-        public string BinFolder { get; set; }
         public bool BuiltinAdminOverride { get; set; } = false;
         public bool SkipRecompute { get; set; } = false;
         public bool EntityFramework__UseDatabaseNullSemantics { get; set; } = false;

--- a/Source/Rhetos/Global.asax.cs
+++ b/Source/Rhetos/Global.asax.cs
@@ -46,7 +46,7 @@ namespace Rhetos
                 .AddRhetosAppConfiguration(AppDomain.CurrentDomain.BaseDirectory)
                 .Build();
 
-            var builder = new RhetosContainerBuilder(configurationProvider, new NLogProvider(), LegacyUtilities.GetListAssembliesDelegate());
+            var builder = new RhetosContainerBuilder(configurationProvider, new NLogProvider(), LegacyUtilities.GetListAssembliesDelegate(configurationProvider));
             AddRhetosComponents(builder);
             AutofacServiceHostFactory.Container = builder.Build();
 

--- a/Source/RhetosCli/NuGetUtilities.cs
+++ b/Source/RhetosCli/NuGetUtilities.cs
@@ -56,7 +56,7 @@ namespace Rhetos
                     //TODO: Add the option name with which the target framework should be pass to  RhetosCli after it is defined
                     throw new FrameworkException("There are multiple targets set. Pass the target version with the command line option.");
                 }
-                if (targets.Count() == 0)
+                if (!targets.Any())
                     throw new FrameworkException("No target framework found for the selected project.");
 
                 return targets.First();

--- a/Source/RhetosCli/Program.cs
+++ b/Source/RhetosCli/Program.cs
@@ -92,8 +92,10 @@ namespace Rhetos
                 .AddRhetosAppEnvironment(new RhetosAppEnvironment
                 {
                     RootPath = rhetosAppRootPath,
-                    BinFolder = Path.Combine(rhetosAppRootPath, @"bin"),
-                    AssetsFolder = Path.Combine(rhetosAppRootPath, @"bin"),
+                    BinFolder = Path.Combine(rhetosAppRootPath, "bin"),
+                    AssetsFolder = Path.Combine(rhetosAppRootPath, "bin"),
+                    LegacyPluginsFolder = Path.Combine(rhetosAppRootPath, "bin", "Plugins"),
+                    LegacyAssetsFolder = Path.Combine(rhetosAppRootPath, "Resources"),
                 })
                 .AddKeyValue(nameof(BuildOptions.CacheFolder), Path.Combine(rhetosAppRootPath, "obj\\Rhetos"))
                 .AddKeyValue(nameof(BuildOptions.GeneratedSourceFolder), Path.Combine(rhetosAppRootPath, "RhetosSource"))

--- a/Source/RhetosCli/Program.cs
+++ b/Source/RhetosCli/Program.cs
@@ -90,7 +90,7 @@ namespace Rhetos
         {
             var configurationProvider = new ConfigurationBuilder()
                 .AddKeyValue("RootPath", rhetosAppRootPath)
-                .AddKeyValue(nameof(AssetsOptions.AssetsFolder), Path.Combine(rhetosAppRootPath, @"bin"))
+                .AddKeyValue(nameof(RhetosAppEnvironment.AssetsFolder), Path.Combine(rhetosAppRootPath, @"bin"))
                 .AddKeyValue(nameof(BuildOptions.CacheFolder), Path.Combine(rhetosAppRootPath, "obj\\Rhetos"))
                 .AddKeyValue(nameof(BuildOptions.GeneratedSourceFolder), Path.Combine(rhetosAppRootPath, "RhetosSource"))
                 .AddConfigurationManagerConfiguration()
@@ -109,7 +109,7 @@ namespace Rhetos
                 .AddRhetosAppConfiguration(rhetosAppRootPath)
                 .AddConfigurationManagerConfiguration()
                 .Build();
-            string binFolder = configurationProvider.GetOptions<RhetosAppOptions>().BinFolder;
+            string binFolder = configurationProvider.GetOptions<RhetosAppEnvironment>().BinFolder;
             var assemblyList = Directory.GetFiles(binFolder, "*.dll");
             var deployment = new ApplicationDeployment(configurationProvider, logProvider, () => assemblyList);
             AppDomain.CurrentDomain.AssemblyResolve += GetSearchForAssemblyDelegate(assemblyList);
@@ -122,7 +122,7 @@ namespace Rhetos
                 .AddRhetosAppConfiguration(rhetosAppRootPath)
                 .AddConfigurationManagerConfiguration()
                 .Build();
-            string binFolder = configurationProvider.GetOptions<RhetosAppOptions>().BinFolder;
+            string binFolder = configurationProvider.GetOptions<RhetosAppEnvironment>().BinFolder;
             var assemblyList = Directory.GetFiles(binFolder, "*.dll");
             var deployment = new ApplicationDeployment(configurationProvider, logProvider, () => assemblyList);
             AppDomain.CurrentDomain.AssemblyResolve += GetSearchForAssemblyDelegate(assemblyList);

--- a/Source/RhetosCli/RhetosCli.csproj
+++ b/Source/RhetosCli/RhetosCli.csproj
@@ -66,61 +66,17 @@
       <Project>{759CEA3C-1CD0-449C-977E-102CE308F4DE}</Project>
       <Name>Rhetos.Configuration.Autofac</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\Source\Rhetos.DatabaseGenerator.Interfaces\Rhetos.DatabaseGenerator.Interfaces.csproj">
-      <Project>{CA29D948-78B1-42D9-8E24-D2811E355F5A}</Project>
-      <Name>Rhetos.DatabaseGenerator.Interfaces</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Source\Rhetos.Dom.Interfaces\Rhetos.Dom.Interfaces.csproj">
-      <Project>{91BDF488-0921-4969-8A53-32169338D8DB}</Project>
-      <Name>Rhetos.Dom.Interfaces</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Source\Rhetos.Dsl.Interfaces\Rhetos.Dsl.Interfaces.csproj">
-      <Project>{F4ACD412-2782-4191-8708-C7AE99B0CEE9}</Project>
-      <Name>Rhetos.Dsl.Interfaces</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Source\Rhetos.Dsl\Rhetos.Dsl.csproj">
-      <Project>{AA08ECFA-2AD6-4B0C-86B9-C5D8754A2073}</Project>
-      <Name>Rhetos.Dsl</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\Source\Rhetos.Logging.Interfaces\Rhetos.Logging.Interfaces.csproj">
       <Project>{BB7E5668-1B43-4FCE-A832-444CC57FEE80}</Project>
       <Name>Rhetos.Logging.Interfaces</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Source\Rhetos.Security.Interfaces\Rhetos.Security.Interfaces.csproj">
-      <Project>{8E1D4ACD-B1AA-433F-9E52-FA50D4A1C9DC}</Project>
-      <Name>Rhetos.Security.Interfaces</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\DeployPackages\DeployPackages.csproj">
-      <Project>{DB291A1A-BD71-4EEA-898A-7B353C7D1EF5}</Project>
-      <Name>DeployPackages</Name>
     </ProjectReference>
     <ProjectReference Include="..\Rhetos.Deployment.Interfaces\Rhetos.Deployment.Interfaces.csproj">
       <Project>{945537dc-4af7-4def-b73c-07f19229efe6}</Project>
       <Name>Rhetos.Deployment.Interfaces</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Rhetos.Deployment\Rhetos.Deployment.csproj">
-      <Project>{A7328BFA-A009-4F1E-B9A1-B51B2020F45C}</Project>
-      <Name>Rhetos.Deployment</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Rhetos.Extensibility.Interfaces\Rhetos.Extensibility.Interfaces.csproj">
-      <Project>{ddc73f5f-bb0e-4944-92cc-4ac937398499}</Project>
-      <Name>Rhetos.Extensibility.Interfaces</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Rhetos.Extensibility\Rhetos.Extensibility.csproj">
-      <Project>{7eaf15bd-39c9-44ab-8834-ec0ae013a8a2}</Project>
-      <Name>Rhetos.Extensibility</Name>
-    </ProjectReference>
     <ProjectReference Include="..\Rhetos.Logging\Rhetos.Logging.csproj">
       <Project>{8c9f1c24-2d9c-420b-9787-3fcad96c5b3e}</Project>
       <Name>Rhetos.Logging</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Rhetos.Persistence.Interfaces\Rhetos.Persistence.Interfaces.csproj">
-      <Project>{5E3BBD83-91CB-4FBA-81B2-79A81EC94D70}</Project>
-      <Name>Rhetos.Persistence.Interfaces</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Rhetos.Security\Rhetos.Security.csproj">
-      <Project>{f3480d1e-1c20-448d-b2f6-133472ceeb93}</Project>
-      <Name>Rhetos.Security</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Using RhetosAppEnvironment instead of AssetsOptions.AssetsFolder and RhetosAppOptions.BinFolder, to group common configuration between build-time and run-time.
Persisting RhetosAppEnvironment from build to be used in runtime.

Other minor improvements:

* Separated build and runtime configuration in DeployPackages.
* Removed excess dependencies from Rhetos CLI.
* Legalized legacy plugins and resources folder. Bringing back legacy constructor for Configuration with LegacyUtilities.Initialize.
* Removed unnecessary ConfigurationProvider usage in ApplicationDeployment (using DI in ApplicationGenerator).
* PluginScannerCache: different filenames for build and run-time.