### PR TITLE
Split source files

### DIFF
--- a/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/DataStructure/DataStructureQueryableCodeGenerator.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/DataStructure/DataStructureQueryableCodeGenerator.cs
@@ -17,18 +17,13 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Globalization;
-using System.ComponentModel.Composition;
 using Rhetos.Compiler;
-using Rhetos.Dsl.DefaultConcepts;
 using Rhetos.Dsl;
+using Rhetos.Dsl.DefaultConcepts;
 using Rhetos.Extensibility;
-using System.Diagnostics.Contracts;
-using Rhetos.Utilities;
+using System;
+using System.ComponentModel.Composition;
+using System.Linq;
 
 namespace Rhetos.Dom.DefaultConcepts
 {
@@ -47,9 +42,9 @@ namespace Rhetos.Dom.DefaultConcepts
 
             if (DslUtility.IsQueryable(info))
             {
-                codeBuilder.InsertCode(SnippetQueryableClass(info), DomInitializationCodeGenerator.CommonQueryableMemebersTag);
-                codeBuilder.InsertCode("IDetachOverride", DataStructureQueryableCodeGenerator.InterfaceTag, info);
-                codeBuilder.InsertCode("bool IDetachOverride.Detaching { get; set; }\r\n\r\n        ", DataStructureQueryableCodeGenerator.MembersTag, info);
+                codeBuilder.InsertCode(SnippetQueryableClass(info), ModuleCodeGenerator.CommonQueryableMemebersTag, info.Module);
+                codeBuilder.InsertCode("IDetachOverride", InterfaceTag, info);
+                codeBuilder.InsertCode("bool IDetachOverride.Detaching { get; set; }\r\n\r\n        ", MembersTag, info);
             }
         }
 

--- a/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/DataStructure/DomInitializationCodeGenerator.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/DataStructure/DomInitializationCodeGenerator.cs
@@ -17,16 +17,11 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-using Microsoft.CSharp.RuntimeBinder;
 using Rhetos.Compiler;
 using Rhetos.Dsl;
-using Rhetos.Dsl.DefaultConcepts;
 using Rhetos.Extensibility;
 using Rhetos.Processing;
-using Rhetos.Utilities;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Linq;
 
 namespace Rhetos.Dom.DefaultConcepts
 {
@@ -54,7 +49,9 @@ namespace Rhetos.Dom.DefaultConcepts
 
         public void GenerateCode(IConceptInfo conceptInfo, ICodeBuilder codeBuilder)
         {
-            codeBuilder.InsertCode(GenerateCommonClassesSnippet());
+            codeBuilder.InsertCodeToFile(ModelSnippet, DomAssemblies.Model.ToString());
+            codeBuilder.InsertCodeToFile(OrmSnippet, DomAssemblies.Orm.ToString());
+            codeBuilder.InsertCodeToFile(RepositoriesSnippet, DomAssemblies.Repositories.ToString());
 
             codeBuilder.InsertCode("this.Configuration.UseDatabaseNullSemantics = _rhetosAppOptions.EntityFramework__UseDatabaseNullSemantics;\r\n            ", EntityFrameworkContextInitializeTag);
 
@@ -81,12 +78,8 @@ namespace Rhetos.Dom.DefaultConcepts
             codeBuilder.AddReferencesFromDependency(typeof(ICommandInfo)); // Used from ApplyFiltersOnClientRead.
         }
 
-        private static string GenerateCommonClassesSnippet()
-        {
-            return $@"
-{DomGeneratorOptions.FileSplitterPrefix}{DomAssemblies.Model}{DomGeneratorOptions.FileSplitterSuffix}
-
-{SimpleClassesTag}
+        private readonly string ModelSnippet =
+$@"{SimpleClassesTag}
 
 namespace Common.Queryable
 {{
@@ -141,10 +134,10 @@ namespace System.Linq
         }}
     }}
 }}
+";
 
-{DomGeneratorOptions.FileSplitterPrefix}{DomAssemblies.Orm}{DomGeneratorOptions.FileSplitterSuffix}
-
-namespace Common
+        private readonly string OrmSnippet =
+$@"namespace Common
 {{
     {StandardNamespacesSnippet}
     using Autofac;
@@ -213,10 +206,10 @@ namespace Common
         }}
     }}
 }}
+";
 
-{DomGeneratorOptions.FileSplitterPrefix}{DomAssemblies.Repositories}{DomGeneratorOptions.FileSplitterSuffix}
-
-namespace Common
+        private readonly string RepositoriesSnippet =
+$@"namespace Common
 {{
     {StandardNamespacesSnippet}
     using Autofac;
@@ -457,6 +450,5 @@ namespace Common
 
 {RepositoryClassesTag}
 ";
-        }
     }
 }

--- a/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/DataStructure/DomInitializationCodeGenerator.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/DataStructure/DomInitializationCodeGenerator.cs
@@ -32,10 +32,7 @@ namespace Rhetos.Dom.DefaultConcepts
         public static readonly string EntityFrameworkContextMembersTag = "/*EntityFrameworkContextMembers*/";
         public static readonly string EntityFrameworkContextInitializeTag = "/*EntityFrameworkContextInitialize*/";
         public static readonly string EntityFrameworkConfigurationTag = "/*EntityFrameworkConfiguration*/";
-        public static readonly string CommonQueryableMemebersTag = "/*CommonQueryableMemebers*/";
         public static readonly string QueryExtensionsMembersTag = "/*QueryExtensionsMembers*/";
-        public static readonly string SimpleClassesTag = "/*SimpleClasses*/";
-        public static readonly string RepositoryClassesTag = "/*RepositoryClasses*/";
 
         public static readonly string StandardNamespacesSnippet =
 @"using System;
@@ -79,16 +76,7 @@ namespace Rhetos.Dom.DefaultConcepts
         }
 
         private readonly string ModelSnippet =
-$@"{SimpleClassesTag}
-
-namespace Common.Queryable
-{{
-    {StandardNamespacesSnippet}
-
-    {CommonQueryableMemebersTag}
-}}
-
-namespace System.Linq
+$@"namespace System.Linq
 {{
     {StandardNamespacesSnippet}
 
@@ -447,8 +435,6 @@ $@"namespace Common
 
     {ModuleCodeGenerator.CommonNamespaceMembersTag}
 }}
-
-{RepositoryClassesTag}
 ";
     }
 }

--- a/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/DataStructure/ModuleCodeGenerator.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/DataStructure/ModuleCodeGenerator.cs
@@ -36,6 +36,7 @@ namespace Rhetos.Dom.DefaultConcepts
         public static readonly CsTag<ModuleInfo> NamespaceMembersTag = "Body";
         public static readonly CsTag<ModuleInfo> RepositoryMembersTag = "RepositoryMembers";
         public static readonly CsTag<ModuleInfo> HelperNamespaceMembersTag = "HelperNamespaceMembers";
+        public static readonly CsTag<ModuleInfo> CommonQueryableMemebersTag = "CommonQueryableMemebers";
 
         private static string ModuleRepositoryInCommonRepositorySnippet(ModuleInfo info)
         {
@@ -51,7 +52,7 @@ namespace Rhetos.Dom.DefaultConcepts
         {
             var info = (ModuleInfo)conceptInfo;
 
-            codeBuilder.InsertCode(
+            codeBuilder.InsertCodeToFile(
 $@"namespace {info.Name}
 {{
     {DomInitializationCodeGenerator.StandardNamespacesSnippet}
@@ -61,9 +62,15 @@ $@"namespace {info.Name}
     {NamespaceMembersTag.Evaluate(info)}
 }}
 
-", DomInitializationCodeGenerator.SimpleClassesTag);
+namespace Common.Queryable
+{{
+    {DomInitializationCodeGenerator.StandardNamespacesSnippet}
 
-            codeBuilder.InsertCode(
+    {CommonQueryableMemebersTag.Evaluate(info)}
+}}
+", $"{DomAssemblies.Model}-{info.Name}");
+
+            codeBuilder.InsertCodeToFile(
 $@"namespace {info.Name}._Helper
 {{
     {DomInitializationCodeGenerator.StandardNamespacesSnippet}
@@ -85,7 +92,7 @@ $@"namespace {info.Name}._Helper
     {HelperNamespaceMembersTag.Evaluate(info)}
 }}
 
-", DomInitializationCodeGenerator.RepositoryClassesTag);
+", $"{DomAssemblies.Repositories}-{info.Name}");
 
             // Default .NET framework assemblies:
             codeBuilder.AddReferencesFromDependency(typeof(int)); // Includes reference to mscorlib.dll

--- a/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/DataStructure/ModuleCodeGenerator.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/DataStructure/ModuleCodeGenerator.cs
@@ -68,7 +68,7 @@ namespace Common.Queryable
 
     {CommonQueryableMemebersTag.Evaluate(info)}
 }}
-", $"{DomAssemblies.Model}-{info.Name}");
+", $"{DomAssemblies.Model}\\{info.Name}{DomAssemblies.Model}");
 
             codeBuilder.InsertCodeToFile(
 $@"namespace {info.Name}._Helper
@@ -92,7 +92,7 @@ $@"namespace {info.Name}._Helper
     {HelperNamespaceMembersTag.Evaluate(info)}
 }}
 
-", $"{DomAssemblies.Repositories}-{info.Name}");
+", $"{DomAssemblies.Repositories}\\{info.Name}{DomAssemblies.Repositories}");
 
             // Default .NET framework assemblies:
             codeBuilder.AddReferencesFromDependency(typeof(int)); // Includes reference to mscorlib.dll

--- a/Source/Rhetos.Compiler.Interfaces/AssemblySource.cs
+++ b/Source/Rhetos.Compiler.Interfaces/AssemblySource.cs
@@ -17,11 +17,13 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-namespace Rhetos.Dom
+using System.Collections.Generic;
+
+namespace Rhetos.Compiler
 {
-    public static class DomGeneratorOptions
+    public class AssemblySource : IAssemblySource
     {
-        public const string FileSplitterPrefix = "/*DomainObjectModel file: ";
-        public const string FileSplitterSuffix = "*/";
+        public string GeneratedCode { get; set; }
+        public IEnumerable<string> RegisteredReferences { get; set; }
     }
 }

--- a/Source/Rhetos.Compiler.Interfaces/IAssemblyGenerator.cs
+++ b/Source/Rhetos.Compiler.Interfaces/IAssemblyGenerator.cs
@@ -24,8 +24,17 @@ using System.Reflection;
 
 namespace Rhetos.Compiler
 {
+    /// <summary>
+    /// This is a legacy utility for building assemblies from the generated C# source.
+    /// Use it for plugins that should work in legacy DeployPackages (build source and DLLs) and Rhetos CLI (build source only).
+    /// Plugins that are designed only for Rhetos CLI, should use ISourceWriter instead.
+    /// </summary>
     public interface IAssemblyGenerator
     {
+        /// <param name="outputAssemblyPath">
+        /// DeployPackages will generate corresponding .cs file and DLL with the provided name.
+        /// Rhetos CLI will generate only the .cs file, ignoring the provided <paramref name="outputAssemblyPath"/> extension and folder.
+        /// </param>
         /// <param name="manifestResources">
         /// Obsolete parameter for legacy plugins.
         /// If provided, Rhetos CLI build command will not consider generated source as a part of the application's source,

--- a/Source/Rhetos.Compiler.Interfaces/IAssemblySource.cs
+++ b/Source/Rhetos.Compiler.Interfaces/IAssemblySource.cs
@@ -17,10 +17,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Rhetos.Compiler
 {

--- a/Source/Rhetos.Compiler.Interfaces/ICodeBuilder.cs
+++ b/Source/Rhetos.Compiler.Interfaces/ICodeBuilder.cs
@@ -35,6 +35,11 @@ namespace Rhetos.Compiler
         void AddReference(string shortName);
         void AddReferencesFromDependency(Type type);
 
+        /// <summary>
+        /// Insert code that is grouped into files.
+        /// <see cref="InsertCode(string)"/> uses empty string for the path.
+        /// </summary>
+        void InsertCodeToFile(string code, string path);
         void InsertCode(string code);
         void InsertCode(string code, string tag);
         void InsertCode(string firstCode, string nextCode, string firstTag, string nextTag);

--- a/Source/Rhetos.Compiler.Interfaces/ICodeGenerator.cs
+++ b/Source/Rhetos.Compiler.Interfaces/ICodeGenerator.cs
@@ -18,16 +18,27 @@
 */
 
 using Rhetos.Extensibility;
+using System.Collections.Generic;
 
 namespace Rhetos.Compiler
 {
+    /// <summary>
+    /// From DSL model and code generator plugins generates source.
+    /// </summary>
     public interface ICodeGenerator
     {
-        /// <param name="initialCodeGenerator">
-        /// Optional.
-        /// Used to initialize generated AssemblyInfo. It will be called with IConceptInfo argument set to null.
-        /// </param>
-        IAssemblySource ExecutePlugins<TPlugin>(IPluginsContainer<TPlugin> pluginRepository, string tagOpen, string tagClose, IConceptCodeGenerator initialCodeGenerator)
+        /// <summary>
+        /// For each concept in DslModel executes registered code generator plugin and returns the generated source code.
+        /// </summary>
+        /// <param name="initialCodeGenerator">Optional. Used to initialize generated AssemblyInfo. It will be called with IConceptInfo argument set to null.</param>
+        IAssemblySource ExecutePlugins<TPlugin>(IPluginsContainer<TPlugin> plugins, string tagOpen, string tagClose, IConceptCodeGenerator initialCodeGenerator)
+            where TPlugin : IConceptCodeGenerator;
+
+        /// <summary>
+        /// For each concept in DslModel executes registered code generator plugin and returns the generated source code split to files.
+        /// </summary>
+        /// <param name="initialCodeGenerator">Optional. Used to initialize generated AssemblyInfo. It will be called with IConceptInfo argument set to null.</param>
+        IDictionary<string, IAssemblySource> ExecutePluginsToFiles<TPlugin>(IPluginsContainer<TPlugin> plugins, string tagOpen, string tagClose, IConceptCodeGenerator initialCodeGenerator)
             where TPlugin : IConceptCodeGenerator;
     }
 }

--- a/Source/Rhetos.Compiler.Interfaces/ISourceWriter.cs
+++ b/Source/Rhetos.Compiler.Interfaces/ISourceWriter.cs
@@ -21,7 +21,10 @@ namespace Rhetos.Compiler
 {
     public interface ISourceWriter
     {
-        void Add(string fileName, string content);
+        /// <param name="relativePath">
+        /// Path should be a file name or a relative path inside the generated source folder.
+        /// </param>
+        void Add(string relativePath, string content);
         void CleanUp();
     }
 }

--- a/Source/Rhetos.Compiler.Interfaces/Rhetos.Compiler.Interfaces.csproj
+++ b/Source/Rhetos.Compiler.Interfaces/Rhetos.Compiler.Interfaces.csproj
@@ -95,6 +95,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AssemblySource.cs" />
     <Compile Include="ISourceWriter.cs" />
     <Compile Include="ManifestResource.cs" />
     <Compile Include="SqlTag.cs" />

--- a/Source/Rhetos.Compiler/CodeBuilder.cs
+++ b/Source/Rhetos.Compiler/CodeBuilder.cs
@@ -25,7 +25,7 @@ using Rhetos.Utilities;
 
 namespace Rhetos.Compiler
 {
-    public class CodeBuilder : ICodeBuilder, IAssemblySource
+    public class CodeBuilder : ICodeBuilder
     {
         private readonly FastReplacer _code;
         private readonly HashSet<string> _references = new HashSet<string>();

--- a/Source/Rhetos.Compiler/CodeBuilder.cs
+++ b/Source/Rhetos.Compiler/CodeBuilder.cs
@@ -59,6 +59,11 @@ namespace Rhetos.Compiler
             }
         }
 
+        public void InsertCodeToFile(string code, string path)
+        {
+            _code.AppendToFile(code, path);
+        }
+
         public void InsertCode(string code)
         {
             _code.Append(code);
@@ -119,17 +124,10 @@ namespace Rhetos.Compiler
             return _code.Contains(tag);
         }
 
-        public string GeneratedCode
-        {
-            get
-            {
-                return _code.ToString();
-            }
-        }
+        public string GeneratedCode => _code.ToString();
 
-        public IEnumerable<string> RegisteredReferences
-        {
-            get { return _references; }
-        }
+        public IDictionary<string, string> GeneratedCodeByFile => _code.GetPaths().ToDictionary(path => path, path => _code.ToString(path));
+
+        public IEnumerable<string> RegisteredReferences => _references;
     }
 }

--- a/Source/Rhetos.Compiler/SourceWriter.cs
+++ b/Source/Rhetos.Compiler/SourceWriter.cs
@@ -41,13 +41,43 @@ namespace Rhetos.Compiler
             _filesUtility = filesUtility;
         }
 
-        public void Add(string fileName, string content)
+        public void Add(string relativePath, string content)
         {
-            _files.AddOrUpdate(fileName, content, ErrorOnUpdate);
+            string filePath = Path.GetFullPath(Path.Combine(_buildOptions.GeneratedSourceFolder, relativePath));
+            if (!filePath.StartsWith(_buildOptions.GeneratedSourceFolder))
+                throw new FrameworkException($"Generated source file '{filePath}' should be inside the folder '{_buildOptions.GeneratedSourceFolder}'." +
+                    $" Provide a simple file name or a relative path for {nameof(ISourceWriter)}.{nameof(ISourceWriter.Add)} method.");
 
-            _logger.Info(() => $"Writing '{fileName}'.");
+            _files.AddOrUpdate(filePath, content, ErrorOnUpdate);
 
-            using (var fs = new FileStream(Path.Combine(_buildOptions.GeneratedSourceFolder, fileName), FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite))
+            if (File.Exists(filePath))
+            {
+                if (File.ReadAllText(filePath, Encoding.UTF8).Equals(content, StringComparison.Ordinal))
+                {
+                    Log("Unchanged", filePath);
+                }
+                else
+                {
+                    Log("Updating", filePath);
+                    WriteFile(content, filePath);
+                }
+            }
+            else
+            {
+                Log("Creating", filePath);
+                _filesUtility.SafeCreateDirectory(Path.GetDirectoryName(filePath));
+                WriteFile(content, filePath);
+            }
+        }
+
+        private string ErrorOnUpdate(string fileName, string oldValue)
+        {
+            throw new FrameworkException($"Multiple code generators are writing same generated file '{fileName}'.");
+        }
+
+        private static void WriteFile(string content, string filePath)
+        {
+            using (var fs = new FileStream(filePath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite))
             {
                 using (var sw = new StreamWriter(fs, Encoding.UTF8))
                 {
@@ -57,21 +87,21 @@ namespace Rhetos.Compiler
             }
         }
 
-        private string ErrorOnUpdate(string fileName, string oldValue)
-        {
-            throw new FrameworkException($"Multiple code generators are writing same generated file '{fileName}'.");
-        }
-
         public void CleanUp()
         {
-            var deleteFiles = Directory.GetFiles(_buildOptions.GeneratedSourceFolder, "*")
-                .Where(existing => !_files.Keys.Contains(Path.GetFileName(existing)));
+            var deleteFiles = Directory.GetFiles(_buildOptions.GeneratedSourceFolder, "*", SearchOption.AllDirectories)
+                .Except(_files.Keys);
 
             foreach (var deleteFile in deleteFiles)
             {
-                _logger.Info(() => $"Deleting '{deleteFile}'.");
+                Log("Deleting", deleteFile);
                 _filesUtility.SafeDeleteFile(deleteFile);
             }
+        }
+
+        private void Log(string title, string filePath, EventType eventType = EventType.Info)
+        {
+            _logger.Write(eventType, () => $"{title} '{FilesUtility.AbsoluteToRelativePath(_buildOptions.GeneratedSourceFolder, filePath)}'.");
         }
     }
 }

--- a/Source/Rhetos.Dom.Interfaces/Rhetos.Dom.Interfaces.csproj
+++ b/Source/Rhetos.Dom.Interfaces/Rhetos.Dom.Interfaces.csproj
@@ -55,7 +55,6 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="DomGeneratorOptions.cs" />
     <Compile Include="IDomainObjectModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Rhetos\Properties\GlobalAssemblyInfo.cs">

--- a/Source/Rhetos.Dom/DomGenerator.cs
+++ b/Source/Rhetos.Dom/DomGenerator.cs
@@ -59,12 +59,12 @@ namespace Rhetos.Dom
                 .Select(sourceFile => new
                 {
                     Name = sourceFile.Key,
-                    AssemblyFile = Paths.GetDomAssemblyFile((DomAssemblies)Enum.Parse(typeof(DomAssemblies), sourceFile.Key)),
                     AssemblySource = new AssemblySource
                     {
                         GeneratedCode = sourceFile.Value.GeneratedCode,
                         RegisteredReferences = sourceFile.Value.RegisteredReferences
-                    }
+                    },
+                    AssemblyFile = Paths.GetDomAssemblyFile((DomAssemblies)Enum.Parse(typeof(DomAssemblies), sourceFile.Key)),
                 })
                 .ToList();
 

--- a/Source/Rhetos.Dom/DomGenerator.cs
+++ b/Source/Rhetos.Dom/DomGenerator.cs
@@ -17,15 +17,12 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-using System;
-using System.Linq;
 using Rhetos.Compiler;
-using System.Reflection;
 using Rhetos.Extensibility;
 using Rhetos.Utilities;
-using Rhetos.Logging;
-using ICodeGenerator = Rhetos.Compiler.ICodeGenerator;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Rhetos.Dom
 {
@@ -34,6 +31,7 @@ namespace Rhetos.Dom
         private readonly IPluginsContainer<IConceptCodeGenerator> _pluginRepository;
         private readonly ICodeGenerator _codeGenerator;
         private readonly IAssemblyGenerator _assemblyGenerator;
+        private readonly BuildOptions _buildOptions;
 
         /// <summary>
         /// If assemblyName is not null, the assembly will be saved on disk.
@@ -42,80 +40,51 @@ namespace Rhetos.Dom
         public DomGenerator(
             IPluginsContainer<IConceptCodeGenerator> plugins,
             ICodeGenerator codeGenerator,
-            IAssemblyGenerator assemblyGenerator)
+            IAssemblyGenerator assemblyGenerator,
+            BuildOptions buildOptions)
         {
             _pluginRepository = plugins;
             _codeGenerator = codeGenerator;
             _assemblyGenerator = assemblyGenerator;
+            _buildOptions = buildOptions;
         }
 
         public IEnumerable<string> Dependencies => Array.Empty<string>();
 
         public void Generate()
         {
-            IAssemblySource assemblySource = _codeGenerator.ExecutePlugins(_pluginRepository, "/*", "*/", null);
+            var sourceFiles = _codeGenerator.ExecutePluginsToFiles(_pluginRepository, "/*", "*/", null);
 
-            foreach (var sourcePart in SplitAssemblySource(assemblySource))
-                _assemblyGenerator.Generate(sourcePart.AssemblySource, sourcePart.AssemblyFileName);
-        }
-
-        private IEnumerable<SourcePart> SplitAssemblySource(IAssemblySource assemblySource)
-        {
-            string source = assemblySource.GeneratedCode;
-            List<string> references = assemblySource.RegisteredReferences.ToList();
-
-            string partName = "";
-            int partStart = 0;
-
-            while (true)
-            {
-                int partEnd = source.IndexOf(DomGeneratorOptions.FileSplitterPrefix, partStart);
-                if (partEnd == -1)
-                    partEnd = source.Length;
-
-                string partSource = source.Substring(partStart, partEnd - partStart).Trim();
-                if (!string.IsNullOrEmpty(partSource))
+            var targetAssemblies = sourceFiles
+                .Select(sourceFile => new
                 {
-                    //TODO: Refactor tis so that it does not use the Paths class
-                    string assemblyFile = Paths.GetDomAssemblyFile((DomAssemblies)Enum.Parse(typeof(DomAssemblies), partName));
-                    yield return new SourcePart
+                    Name = sourceFile.Key,
+                    AssemblyFile = Paths.GetDomAssemblyFile((DomAssemblies)Enum.Parse(typeof(DomAssemblies), sourceFile.Key)),
+                    AssemblySource = new AssemblySource
                     {
-                        AssemblyFileName = assemblyFile,
-                        AssemblySource = new SimpleAssemplySource
-                        {
-                            GeneratedCode = partSource,
-                            RegisteredReferences = references
-                        }
-                    };
-                    references = references.ToList(); // Create a new list to avoid changing the one provided to the assembly above.
-                    references.Add(assemblyFile);
-                }
+                        GeneratedCode = sourceFile.Value.GeneratedCode,
+                        RegisteredReferences = sourceFile.Value.RegisteredReferences
+                    }
+                })
+                .ToList();
 
-                if (partEnd == source.Length)
-                    break;
-
-                int tagStart = partEnd + DomGeneratorOptions.FileSplitterPrefix.Length;
-                int tagEnd = source.IndexOf(DomGeneratorOptions.FileSplitterSuffix, tagStart);
-                if (tagEnd == -1)
-                    throw new FrameworkException($"Unexpected file splitter tag format. Cannot find tag end mark ({DomGeneratorOptions.FileSplitterSuffix})"
-                        + $" after position {tagStart - partEnd} in source:\r\n"
-                        + source.Substring(partEnd, 200));
-
-                partName = source.Substring(tagStart, tagEnd - tagStart);
-                partStart = tagEnd + DomGeneratorOptions.FileSplitterSuffix.Length;
+            if (string.IsNullOrEmpty(_buildOptions.GeneratedSourceFolder))
+            {
+                // Set dependencies between the assemblies:
+                Graph.SortByGivenOrder(targetAssemblies,
+                    new string[] { DomAssemblies.Model.ToString(), DomAssemblies.Orm.ToString(), DomAssemblies.Repositories.ToString() },
+                    targetAssembly => targetAssembly.Name);
+                AddReferences(targetAssemblies[1].AssemblySource, new[] { targetAssemblies[0].AssemblyFile });
+                AddReferences(targetAssemblies[2].AssemblySource, new[] { targetAssemblies[0].AssemblyFile, targetAssemblies[1].AssemblyFile });
             }
+
+            foreach (var targetAssembly in targetAssemblies)
+                _assemblyGenerator.Generate(targetAssembly.AssemblySource, targetAssembly.AssemblyFile);
         }
 
-        private class SourcePart
+        private void AddReferences(AssemblySource targetAssembly, string[] additionalReferences)
         {
-            public string AssemblyFileName;
-            public IAssemblySource AssemblySource;
-        }
-
-        private class SimpleAssemplySource : IAssemblySource
-        {
-            public string GeneratedCode { get; set; }
-            public IEnumerable<string> RegisteredReferences { get; set; }
+            targetAssembly.RegisteredReferences = targetAssembly.RegisteredReferences.Concat(additionalReferences).ToList();
         }
     }
 }


### PR DESCRIPTION
* When building with rhetos.exe, ServerDom.Model.cs and ServerDom.Repositories.cs are split to separate source files for each Module.
* Optimized build to leave the unchanged source files if the content is same. We might improve that in future by keeping list of source file hashes.