### PR TITLE
CLI default folder and minor improvements

### DIFF
--- a/Source/CleanUpOldData/Program.cs
+++ b/Source/CleanUpOldData/Program.cs
@@ -35,7 +35,7 @@ namespace CleanupOldData
             try
             {
                 var configuration = new ConfigurationBuilder()
-                    .AddRhetosAppConfiguration(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ".."))
+                    .AddRhetosAppConfiguration()
                     .AddConfigurationManagerConfiguration()
                     .Build();
 

--- a/Source/Rhetos.Configuration.Autofac/RhetosTestContainer.cs
+++ b/Source/Rhetos.Configuration.Autofac/RhetosTestContainer.cs
@@ -49,7 +49,6 @@ namespace Rhetos.Configuration.Autofac
 
         /// <param name="commitChanges">
         /// Whether database updates (by ORM repositories) will be committed or rollbacked.
-        /// Note: Database updates done by SqlExecuter are always instantly committed.
         /// </param>
         /// <param name="rhetosServerFolder">
         /// If not set, the class will try to automatically locate Rhetos server, looking from current directory.

--- a/Source/Rhetos.Utilities/ApplicationConfiguration/ConfigurationSources/ConfigurationSourcesBuilderExtensions.cs
+++ b/Source/Rhetos.Utilities/ApplicationConfiguration/ConfigurationSources/ConfigurationSourcesBuilderExtensions.cs
@@ -95,12 +95,7 @@ namespace Rhetos
             return builder;
         }
 
-        /// <summary>
-        /// Initializes run-time configuration for the Rhetos application, for usage in utility applications that references the Rhetos application's libraries.
-        /// Searches for Rhetos application root path in the current application's folder (see <see cref="AppDomain.CurrentDomain.BaseDirectory"/>) or any parent folder.
-        /// Loads Rhetos application's configuration files.
-        /// </summary>
-        public static IConfigurationBuilder AddRhetosAppConfiguration(this IConfigurationBuilder builder)
+        private static string SearchForRhetosApp()
         {
             string startingPath = AppDomain.CurrentDomain.BaseDirectory;
             var rhetosAppFolder = new DirectoryInfo(startingPath);
@@ -108,9 +103,9 @@ namespace Rhetos
             while (true)
             {
                 if (RhetosAppEnvironmentProvider.IsRhetosApplicationRootFolder(rhetosAppFolder.FullName))
-                    return AddRhetosAppConfiguration(builder, rhetosAppFolder.FullName);
+                    return rhetosAppFolder.FullName;
                 if (rhetosAppFolder.Parent == null)
-                    throw new FrameworkException($"Cannot locate a valid Rhetos application folder starting in '{startingPath}' or any parent folder.");
+                    throw new FrameworkException($"Cannot locate Rhetos application in '{startingPath}' or any parent folder.");
                 rhetosAppFolder = rhetosAppFolder.Parent;
             }
         }
@@ -118,9 +113,13 @@ namespace Rhetos
         /// <summary>
         /// Initializes run-time configuration for the Rhetos application, for usage in utility applications that references the Rhetos application's libraries.
         /// Loads Rhetos application's configuration files.
+        /// If <paramref name="rhetosAppRootPath"/> is not specified, it searches for Rhetos application root path in the current application's folder (AppDomain.CurrentDomain.BaseDirectory) or any parent folder.
         /// </summary>
-        public static IConfigurationBuilder AddRhetosAppConfiguration(this IConfigurationBuilder builder, string rhetosAppRootPath)
+        public static IConfigurationBuilder AddRhetosAppConfiguration(this IConfigurationBuilder builder, string rhetosAppRootPath = null)
         {
+            if (string.IsNullOrEmpty(rhetosAppRootPath))
+                rhetosAppRootPath = SearchForRhetosApp();
+
             var rhetosAppEnvironment = RhetosAppEnvironmentProvider.Load(rhetosAppRootPath);
             return builder
                 .AddRhetosAppEnvironment(rhetosAppEnvironment)

--- a/Source/Rhetos.Utilities/ApplicationConfiguration/RhetosAppEnvironmentProvider.cs
+++ b/Source/Rhetos.Utilities/ApplicationConfiguration/RhetosAppEnvironmentProvider.cs
@@ -59,7 +59,7 @@ namespace Rhetos.Utilities.ApplicationConfiguration
             if (!File.Exists(filePath))
                 throw new FrameworkException($"Please verify that the Rhetos build have passed successfully," +
                     $" and that the specified folder contains a valid Rhetos application." +
-                    $" Missing file '{RhetosAppEnvironmentFileName}' in folder '{rhetosAppRootPath}' or subfolders.");
+                    $" Missing file '{RhetosAppEnvironmentFileName}' in folder '{rhetosAppRootPath}'.");
 
             string saveFolder = Path.GetDirectoryName(filePath);
             var serialized = File.ReadAllText(filePath, Encoding.UTF8);

--- a/Source/Rhetos.Utilities/ConsoleLogProvider.cs
+++ b/Source/Rhetos.Utilities/ConsoleLogProvider.cs
@@ -86,7 +86,7 @@ namespace Rhetos.Utilities
                 + message);
         }
 
-        public static EventType MinLevel { get; set; } = 0;
+        public static EventType MinLevel { get; set; } = EventType.Info;
 
         public string Name { get; }
     }

--- a/Source/Rhetos.nuspec
+++ b/Source/Rhetos.nuspec
@@ -15,6 +15,7 @@
     </dependencies>
     <contentFiles>
       <files include="any/any/rhetos.exe" buildAction="None" copyToOutput="true" />
+      <files include="any/any/rhetos.pdb" buildAction="None" copyToOutput="true" />
       <files include="any/any/rhetos.exe.config" buildAction="None" copyToOutput="true" />
     </contentFiles>
   </metadata>
@@ -30,6 +31,7 @@
     <file src="RhetosVSIntegration\bin\Debug\*.pdb" target="build" />
 
     <file src="RhetosCli\bin\Debug\rhetos.exe" target="contentFiles/any/any" />
+    <file src="RhetosCli\bin\Debug\rhetos.pdb" target="contentFiles/any/any" />
     <file src="RhetosCli\bin\Debug\rhetos.exe.config" target="contentFiles/any/any" />
   </files>
 </package>


### PR DESCRIPTION
* Rhetos CLI on deployment is expected to be in application folder by default.
* PDB included with rhetos.exe for debugging,
* Default logging level should be Info (this logger is mostly for unit tests),
* Incorrect comment in RhetosTestContainer (SqlExecuter now uses shared transaction).