### PR TITLE
Simplified logging

### DIFF
--- a/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/DataMigrationTest.cs
+++ b/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/DataMigrationTest.cs
@@ -137,10 +137,11 @@ namespace CommonConcepts.Test
                 [Trace] DataMigration: Script on disk p1\s3.sql (tag p1\s3)
                 [Trace] DataMigration: Script on disk p2\ss1.sql (tag p2\ss1)
                 [Trace] DataMigration: Script on disk p2\ss3.sql (tag p2\ss3)
-                [Info] DataMigration: Execute p1\s1.sql (tag p1\s1)
-                [Info] DataMigration: Execute p1\s3.sql (tag p1\s3)
-                [Info] DataMigration: Execute p2\ss1.sql (tag p2\ss1)
-                [Info] DataMigration: Execute p2\ss3.sql (tag p2\ss3)
+                [Info] DataMigration: Executing p1\s1.sql (tag p1\s1)
+                [Info] DataMigration: Executing p1\s3.sql (tag p1\s3)
+                [Info] DataMigration: Executing p2\ss1.sql (tag p2\ss1)
+                [Info] DataMigration: Executing p2\ss3.sql (tag p2\ss3)
+                [Info] DataMigration: Executed 4 of 4 scripts.
                 [Trace] DataMigration: Script on disk p1\s1.sql (tag p1\s1)
                 [Trace] DataMigration: Script on disk p1\s2.sql (tag p1\s2)
                 [Trace] DataMigration: Script on disk p1\s3.sql (tag p1\s3)
@@ -155,12 +156,13 @@ namespace CommonConcepts.Test
                 [Trace] DataMigration: Script in database p2\ss3.sql (tag p2\ss3)
                 [Trace] DataMigration: Last executed script in 'p1' is 'p1\s3.sql' of new scripts provided.
                 [Trace] DataMigration: Last executed script in 'p2' is 'p2\ss3.sql' of new scripts provided.
-                [Info] DataMigration: Executing script in an incorrect order p1\s2.sql (tag p1\s2)
-                [Info] DataMigration: Executing script in an incorrect order p2\ss2.sql (tag p2\ss2)
-                [Info] DataMigration: Execute p1\s2.sql (tag p1\s2)
-                [Info] DataMigration: Execute p1\s4.sql (tag p1\s4)
-                [Info] DataMigration: Execute p2\ss2.sql (tag p2\ss2)
-                [Info] DataMigration: Execute p2\ss4.sql (tag p2\ss4)";
+                [Warning] DataMigration: Executing script in an incorrect order p1\s2.sql (tag p1\s2)
+                [Warning] DataMigration: Executing script in an incorrect order p2\ss2.sql (tag p2\ss2)
+                [Info] DataMigration: Executing p1\s2.sql (tag p1\s2)
+                [Info] DataMigration: Executing p1\s4.sql (tag p1\s4)
+                [Info] DataMigration: Executing p2\ss2.sql (tag p2\ss2)
+                [Info] DataMigration: Executing p2\ss4.sql (tag p2\ss4)
+                [Info] DataMigration: Executed 4 of 8 scripts.";
 
             Assert.AreEqual(expectedLog, string.Concat(log
                 .Where(l => l.Contains("] DataMigration:"))
@@ -180,11 +182,13 @@ namespace CommonConcepts.Test
 
             var expectedLog = @"
                 [Trace] DataMigration: Script on disk p1\s3.sql (tag p1\s3)
-                [Info] DataMigration: Execute p1\s3.sql (tag p1\s3)
+                [Info] DataMigration: Executing p1\s3.sql (tag p1\s3)
+                [Info] DataMigration: Executed 1 of 1 scripts.
                 [Trace] DataMigration: Script on disk p1\s1.sql (tag p1\s1)
                 [Trace] DataMigration: Script in database p1\s3.sql (tag p1\s3)
-                [Info] DataMigration: Remove p1\s3.sql (tag p1\s3)
-                [Info] DataMigration: Execute p1\s1.sql (tag p1\s1)";
+                [Info] DataMigration: Removing p1\s3.sql (tag p1\s3)
+                [Info] DataMigration: Executing p1\s1.sql (tag p1\s1)
+                [Info] DataMigration: Executed 1 of 1 scripts.";
 
             Assert.AreEqual(expectedLog, string.Concat(log
                 .Where(l => l.Contains("] DataMigration:"))
@@ -208,10 +212,11 @@ namespace CommonConcepts.Test
                 [Trace] DataMigration: Script on disk p1\s3.sql (tag p1\s3)
                 [Trace] DataMigration: Script on disk p2\ss1.sql (tag p2\ss1)
                 [Trace] DataMigration: Script on disk p2\ss3.sql (tag p2\ss3)
-                [Info] DataMigration: Execute p1\s1.sql (tag p1\s1)
-                [Info] DataMigration: Execute p1\s3.sql (tag p1\s3)
-                [Info] DataMigration: Execute p2\ss1.sql (tag p2\ss1)
-                [Info] DataMigration: Execute p2\ss3.sql (tag p2\ss3)
+                [Info] DataMigration: Executing p1\s1.sql (tag p1\s1)
+                [Info] DataMigration: Executing p1\s3.sql (tag p1\s3)
+                [Info] DataMigration: Executing p2\ss1.sql (tag p2\ss1)
+                [Info] DataMigration: Executing p2\ss3.sql (tag p2\ss3)
+                [Info] DataMigration: Executed 4 of 4 scripts.
                 [Trace] DataMigration: Script on disk p1\s1.sql (tag p1\s1)
                 [Trace] DataMigration: Script on disk p1\s2.sql (tag p1\s2)
                 [Trace] DataMigration: Script on disk p1\s3.sql (tag p1\s3)
@@ -226,10 +231,11 @@ namespace CommonConcepts.Test
                 [Trace] DataMigration: Script in database p2\ss3.sql (tag p2\ss3)
                 [Trace] DataMigration: Last executed script in 'p1' is 'p1\s3.sql' of new scripts provided.
                 [Trace] DataMigration: Last executed script in 'p2' is 'p2\ss3.sql' of new scripts provided.
-                [Info] DataMigration: Skipped older script p1\s2.sql (tag p1\s2)
-                [Info] DataMigration: Skipped older script p2\ss2.sql (tag p2\ss2)
-                [Info] DataMigration: Execute p1\s4.sql (tag p1\s4)
-                [Info] DataMigration: Execute p2\ss4.sql (tag p2\ss4)";
+                [Warning] DataMigration: Skipped older script p1\s2.sql (tag p1\s2)
+                [Warning] DataMigration: Skipped older script p2\ss2.sql (tag p2\ss2)
+                [Info] DataMigration: Executing p1\s4.sql (tag p1\s4)
+                [Info] DataMigration: Executing p2\ss4.sql (tag p2\ss4)
+                [Info] DataMigration: Executed 2 of 8 scripts. 2 older skipped.";
 
             Assert.AreEqual(expectedLog, string.Concat(log
                 .Where(l => l.Contains("] DataMigration:"))

--- a/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/Authorization/AuthorizationDataLoader.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/Authorization/AuthorizationDataLoader.cs
@@ -87,7 +87,7 @@ namespace Rhetos.Dom.DefaultConcepts
                     {
                         if (ex.Message.StartsWith("Cannot insert duplicate key row in object 'Common.Principal' with unique index 'IX_Principal_Name'"))
                         {
-                            _logger.Info(() => "Ignoring concurrent principal creation: " + ex.GetType().Name + ": " + ex.Message);
+                            _logger.Warning(() => "Ignoring concurrent principal creation: " + ex.GetType().Name + ": " + ex.Message);
                             principal.ID = GetPrincipalID(username);
                             if (principal.ID == default(Guid))
                                 throw new FrameworkException("Cannot create the principal record for '" + username + "'.", ex);
@@ -98,7 +98,7 @@ namespace Rhetos.Dom.DefaultConcepts
                 }
                 else
                 {
-                    _logger.Info($"There is no principal with the username '{username}' in Common.Principal.");
+                    _logger.Warning($"There is no principal with the username '{username}' in Common.Principal.");
                     throw new UserException($"Your account '{username}' is not registered in the system. Please contact the system administrator.");
                 }
             }

--- a/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/KeepSynchronizedRecomputeOnDeploy.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/KeepSynchronizedRecomputeOnDeploy.cs
@@ -78,19 +78,19 @@ namespace Rhetos.Dom.DefaultConcepts
             {
                 if (skipRecomputeDeployParameter)
                 {
-                    _logger.Info(() => $"Skipped recomputing {compute.Target} from {compute.Source} due to deployment parameter.");
+                    _logger.Warning(() => $"Skipped recomputing {compute.Target} from {compute.Source} due to deployment parameter.");
                 }
                 else if (skipRecomputeDslConcept.Contains(GetComputationKey(compute)))
                 {
-                    _logger.Info(() => $"Skipped recomputing {compute.Target} from {compute.Source} due to DSL concept.");
+                    _logger.Warning(() => $"Skipped recomputing {compute.Target} from {compute.Source} due to DSL concept.");
                 }
                 else if (skipRecomputeDbMetadata.Contains(GetComputationKey(compute)))
                 {
-                    _logger.Info(() => $"Skipped recomputing {compute.Target} from {compute.Source} due to database metadata.");
+                    _logger.Warning(() => $"Skipped recomputing {compute.Target} from {compute.Source} due to database metadata.");
                 }
                 else
                 {
-                    _logger.Info(() => $"Recomputing {compute.Target} from {compute.Source}.");
+                    _logger.Warning(() => $"Recomputing {compute.Target} from {compute.Source}.");
                     _genericRepositories.GetGenericRepository(compute.Target).RecomputeFrom(compute.Source);
                     _performanceLogger.Write(sw, () => $"{nameof(KeepSynchronizedRecomputeOnDeploy)}: {compute.Target} from {compute.Source}.");
                 }

--- a/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/Persistence/EntityFrameworkMetadata.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/Persistence/EntityFrameworkMetadata.cs
@@ -91,7 +91,7 @@ namespace Rhetos.Dom.DefaultConcepts.Persistence
                 if (existingManifestToken.Value == EntityFrameworkMappingGenerator.ProviderManifestTokenPlaceholder)
                     _logger.Trace($@"Setting ProviderManifestToken to {expectedManifestToken}.");
                 else
-                    _logger.Info($@"Changing ProviderManifestToken from {existingManifestToken.Value} to {expectedManifestToken}.");
+                    _logger.Warning($@"Changing ProviderManifestToken from {existingManifestToken.Value} to {expectedManifestToken}.");
 
                 var lines = File.ReadAllLines(ssdlFile, Encoding.UTF8);
                 lines[0] = ssdlFirstLine.Substring(0, existingManifestToken.Index)

--- a/CreateInstallationPackage.bat
+++ b/CreateInstallationPackage.bat
@@ -12,10 +12,10 @@ CALL Source\Rhetos\GetServerFiles.bat %Config% /NOPAUSE || GOTO Error0
 REM Packing the files with an older version of nuget.exe for backward compatibility (spaces in file names, https://github.com/Rhetos/Rhetos/issues/80).
 IF NOT EXIST Install\NuGet.exe POWERSHELL (New-Object System.Net.WebClient).DownloadFile('https://dist.nuget.org/win-x86-commandline/v4.5.1/nuget.exe', 'Install\NuGet.exe') || GOTO Error0
 
-Install\NuGet.exe pack Source\Rhetos.Core.nuspec -OutputDirectory Install || GOTO Error0
-Install\NuGet.exe pack Source\Rhetos.nuspec -OutputDirectory Install || GOTO Error0
-Install\NuGet.exe pack CommonConcepts\Rhetos.CommonConcepts.nuspec -OutputDirectory Install || GOTO Error0
+NuGet.exe pack Source\Rhetos.Core.nuspec -OutputDirectory Install || GOTO Error0
+NuGet.exe pack Source\Rhetos.nuspec -OutputDirectory Install || GOTO Error0
 NuGet.exe pack Source\Rhetos.Wcf.nuspec -OutputDirectory Install || GOTO Error0
+Install\NuGet.exe pack CommonConcepts\Rhetos.CommonConcepts.nuspec -OutputDirectory Install || GOTO Error0
 
 MD Install\RhetosServer
 MD Install\RhetosServer\bin

--- a/Source/DeployPackages/App.config
+++ b/Source/DeployPackages/App.config
@@ -26,10 +26,10 @@
   <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" throwExceptions="true">
     <targets>
       <target name="ConsoleLog" xsi:type="ColoredConsole" layout="[${level}] ${logger}: ${message}">
-        <highlight-row condition="level == LogLevel.Error" foregroundColor="Red" backgroundColor="Black"/>
-        <highlight-row condition="level == LogLevel.Warn" foregroundColor="Yellow" backgroundColor="Black"/>
-        <highlight-row condition="level == LogLevel.Info" foregroundColor="Gray" backgroundColor="Black"/>
-        <highlight-row condition="level == LogLevel.Trace" foregroundColor="DarkGray" backgroundColor="Black"/>
+        <highlight-row condition="level == LogLevel.Error" foregroundColor="Red" backgroundColor="NoChange"/>
+        <highlight-row condition="level == LogLevel.Warn" foregroundColor="Yellow" backgroundColor="NoChange"/>
+        <highlight-row condition="level == LogLevel.Info" foregroundColor="NoChange" backgroundColor="NoChange"/>
+        <highlight-row condition="level == LogLevel.Trace" foregroundColor="DarkGray" backgroundColor="NoChange"/>
       </target>
       <target name="MainLog" xsi:type="File" fileName="${basedir}\..\Logs\DeployPackages.log" encoding="utf-8"
         archiveFileName="${basedir}\..\Logs\Archives\DeployPackages {#####}.zip" enableArchiveFileCompression="true" archiveAboveSize="2000000" archiveNumbering="DateAndSequence" />

--- a/Source/DeployPackages/App.config
+++ b/Source/DeployPackages/App.config
@@ -25,41 +25,25 @@
   </runtime>
   <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" throwExceptions="true">
     <targets>
-      <target name="MainLog" xsi:type="File" fileName="${basedir}\..\Logs\DeployPackages.log" encoding="utf-8"
-        archiveFileName="${basedir}\..\Logs\Archives\DeployPackages {#####}.zip" enableArchiveFileCompression="true" archiveAboveSize="2000000" archiveNumbering="DateAndSequence" />
       <target name="ConsoleLog" xsi:type="ColoredConsole" layout="[${level}] ${logger}: ${message}">
         <highlight-row condition="level == LogLevel.Error" foregroundColor="Red" backgroundColor="Black"/>
-        <highlight-row condition="level == LogLevel.Info" foregroundColor="Yellow" backgroundColor="Black"/>
-        <highlight-row condition="level == LogLevel.Trace" foregroundColor="Gray" backgroundColor="Black"/>
+        <highlight-row condition="level == LogLevel.Warn" foregroundColor="Yellow" backgroundColor="Black"/>
+        <highlight-row condition="level == LogLevel.Info" foregroundColor="Gray" backgroundColor="Black"/>
+        <highlight-row condition="level == LogLevel.Trace" foregroundColor="DarkGray" backgroundColor="Black"/>
+      </target>
+      <target name="MainLog" xsi:type="File" fileName="${basedir}\..\Logs\DeployPackages.log" encoding="utf-8"
+        archiveFileName="${basedir}\..\Logs\Archives\DeployPackages {#####}.zip" enableArchiveFileCompression="true" archiveAboveSize="2000000" archiveNumbering="DateAndSequence" />
+      <target name="PerformanceLog" xsi:type="AsyncWrapper" overflowAction="Block">
+        <target name="PerformanceLogBase" xsi:type="File" fileName="${basedir}\..\Logs\DeployPackagesPerformance.log" encoding="utf-8" deleteOldFileOnStartup="true"/>
       </target>
       <target name="TraceLog" xsi:type="AsyncWrapper" overflowAction="Block">
         <target name="TraceLogBase" xsi:type="File" fileName="${basedir}\..\Logs\DeployPackagesTrace.log" encoding="utf-8" deleteOldFileOnStartup="true"/>
       </target>
-      <target name="PerformanceLog" xsi:type="AsyncWrapper" overflowAction="Block">
-        <target name="PerformanceLogBase" xsi:type="File" fileName="${basedir}\..\Logs\DeployPackagesPerformance.log" encoding="utf-8" deleteOldFileOnStartup="true"/>
-      </target>
-      <target name="KeywordsLog" xsi:type="File" fileName="${basedir}\..\Logs\DeployPackagesKeywords.log" encoding="utf-8" deleteOldFileOnStartup="true"/>
-      <target name="MacroEvaluatorsOrderLog" xsi:type="File" fileName="${basedir}\..\Logs\DeployPackagesMacroEvaluatorsOrder.log" encoding="utf-8" deleteOldFileOnStartup="true"/>
     </targets>
     <rules>
-      <logger name="*" minLevel="Info" writeTo="MainLog"/>
-      <logger name="AssemblyGenerator" level="Trace" writeTo="MainLog"/>
-      <logger name="ClaimGenerator Claims" level="Trace" writeTo="MainLog"/>
-      <logger name="DatabaseGenerator Concepts" level="Trace" writeTo="MainLog"/>
-      <logger name="DatabaseGenerator ModifiedObjects" level="Trace" writeTo="MainLog"/>
-      <logger name="DeployPackages" level="Trace" writeTo="MainLog"/>
-      <logger name="FileSyncer" level="Trace" writeTo="MainLog"/>
-      <logger name="NuGet" level="Trace" writeTo="MainLog"/>
-      <logger name="PackageDownloader" level="Trace" writeTo="MainLog"/>
-      <logger name="Packages" level="Trace" writeTo="MainLog"/>
-      <logger name="AfterDeploy" level="Trace" writeTo="MainLog"/>
       <logger name="*" minLevel="Info" writeTo="ConsoleLog"/>
-      <logger name="AssemblyGenerator" level="Trace" writeTo="ConsoleLog"/>
-      <logger name="DeployPackages" level="Trace" writeTo="ConsoleLog"/>
-      <logger name="FilesUtility" level="Trace" writeTo="ConsoleLog"/>
-      <logger name="NuGet" level="Trace" writeTo="ConsoleLog"/>
-      <logger name="DslParser.Keywords" minLevel="Trace" writeTo="KeywordsLog"/>
-      <!-- <logger name="MacroEvaluatorsOrder" minLevel="Trace" writeTo="MacroEvaluatorsOrderLog"/> -->
+      <logger name="*" minLevel="Info" writeTo="MainLog"/>
+      <logger name="DatabaseGeneratorChanges" level="Trace" writeTo="MainLog"/>
       <logger name="Performance" minLevel="Trace" writeTo="PerformanceLog"/>
       <!-- <logger name="*" minLevel="Trace" writeTo="TraceLog"/> -->
     </rules>

--- a/Source/DeployPackages/Program.cs
+++ b/Source/DeployPackages/Program.cs
@@ -192,7 +192,7 @@ namespace DeployPackages
             foreach (var path in deleteObsoleteFiles)
                 if (File.Exists(path))
                 {
-                    logger.Info($"Deleting obsolete file '{path}'.");
+                    logger.Warning($"Deleting obsolete file '{path}'.");
                     filesUtility.SafeDeleteFile(path);
                 }
         }

--- a/Source/DeployPackages/Program.cs
+++ b/Source/DeployPackages/Program.cs
@@ -46,7 +46,7 @@ namespace DeployPackages
             var logger = logProvider.GetLogger("DeployPackages");
             var pauseOnError = false;
 
-            logger.Trace(() => "Logging configured.");
+            logger.Info(() => "Logging configured.");
 
             try
             {
@@ -110,7 +110,7 @@ namespace DeployPackages
                     deployment.RestartWebServer();
                 }
 
-                logger.Trace("Done.");
+                logger.Info("Done.");
             }
             catch (Exception e)
             {

--- a/Source/MsBuildIntegration/Rhetos.targets
+++ b/Source/MsBuildIntegration/Rhetos.targets
@@ -9,7 +9,7 @@
     <Target Name="BuildRhetosApp" DependsOnTargets="ResolveRhetosProjectAssets;" BeforeTargets="CoreCompile" Condition="'$(RhetosBuild)'=='True' and $(BuildingProject)=='True'" Inputs="@(RhetosInput);@(RhetosBuild)" Outputs="@(RhetosOutput)">
 		<Message Text="BuildRhetosApp" />
         <Delete Files="$(RhetosBuildCompleteFile)" />
-        <Exec Command="&quot;$(RhetosCliExecutablePath)&quot; build &quot;$(ProjectDir).&quot;" CustomErrorRegularExpression="\[Error\]" CustomWarningRegularExpression="\[Warning\]" />
+        <Exec Command="&quot;$(RhetosCliExecutablePath)&quot; build &quot;$(ProjectDir).&quot;" CustomErrorRegularExpression="\[Error\]" CustomWarningRegularExpression="\[Warn\]" />
         <WriteLinesToFile File="$(RhetosBuildCompleteFile)" Lines="" Overwrite="true" />
     </Target>
 
@@ -35,8 +35,8 @@
     <Target Name="DeployRhetosApp" DependsOnTargets="BuildRhetosApp;CopyFilesToOutputDirectory" AfterTargets="Build" Condition="'$(RhetosDeploy)'=='True' And Exists('$(RhetosBuildCompleteFile)')"
 		Inputs="$(RhetosBuildCompleteFile)" Outputs="$(RhetosDatabaseUpdated)">
 		<Message Text="DeployRhetosApp" />
-        <Exec Command="&quot;$(TargetDir)rhetos.exe&quot; dbupdate &quot;$(ProjectDir).&quot;" CustomErrorRegularExpression="\[Error\]" CustomWarningRegularExpression="\[Warning\]" />
-        <Exec Command="&quot;$(TargetDir)rhetos.exe&quot; appinitialize &quot;$(ProjectDir).&quot;" CustomErrorRegularExpression="\[Error\]" CustomWarningRegularExpression="\[Warning\]" />
+        <Exec Command="&quot;$(TargetDir)rhetos.exe&quot; dbupdate &quot;$(ProjectDir).&quot;" CustomErrorRegularExpression="\[Error\]" CustomWarningRegularExpression="\[Warn\]" />
+        <Exec Command="&quot;$(TargetDir)rhetos.exe&quot; appinitialize &quot;$(ProjectDir).&quot;" CustomErrorRegularExpression="\[Error\]" CustomWarningRegularExpression="\[Warn\]" />
 		<WriteLinesToFile File="$(RhetosDatabaseUpdated)" Lines="" Overwrite="true" />
     </Target>
 </Project>

--- a/Source/Rhetos.Compiler/AssemblyGenerator.cs
+++ b/Source/Rhetos.Compiler/AssemblyGenerator.cs
@@ -20,7 +20,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Emit;
-using Rhetos.Dom;
 using Rhetos.Logging;
 using Rhetos.Utilities;
 using System;
@@ -102,7 +101,7 @@ namespace Rhetos.Compiler
 
             if (sourceHash.SequenceEqual(_cacheUtility.LoadHash(sourcePath)) && TryRestoreCachedFiles(outputAssemblyPath, pdbPath))
             {
-                _logger.Trace(() => "Restoring assembly from cache: " + dllName + ".");
+                _logger.Info(() => "Restoring assembly from cache: " + dllName + ".");
                 if (!File.Exists(outputAssemblyPath))
                     throw new FrameworkException($"AssemblyGenerator: RestoreCachedFiles failed to create the assembly file ({dllName}).");
 
@@ -114,7 +113,7 @@ namespace Rhetos.Compiler
             }
             else
             {
-                _logger.Trace(() => "Compiling assembly: " + dllName + ".");
+                _logger.Info(() => "Compiling assembly: " + dllName + ".");
 
                 var references = registeredReferences
                     .Select(reference => MetadataReference.CreateFromFile(reference)).ToList();

--- a/Source/Rhetos.Compiler/AssemblyGenerator.cs
+++ b/Source/Rhetos.Compiler/AssemblyGenerator.cs
@@ -259,7 +259,7 @@ namespace Rhetos.Compiler
                 .GroupBy(warning => warning.Id + DescriptionIfObsolete(warning))
                 .Select(warningGroup => $"{warningGroup.First()}{MultipleWarningsInfo(warningGroup.Count())}"));
 
-            _logger.Info($"{warnings.Count} warning(s) while compiling {Path.GetFileName(outputAssemblyPath)}:\r\n{warningDetails}");
+            _logger.Warning($"{warnings.Count} warning(s) while compiling {Path.GetFileName(outputAssemblyPath)}:\r\n{warningDetails}");
         }
 
         private string MultipleWarningsInfo(int count)

--- a/Source/Rhetos.Compiler/SourceWriter.cs
+++ b/Source/Rhetos.Compiler/SourceWriter.cs
@@ -59,13 +59,13 @@ namespace Rhetos.Compiler
                 }
                 else
                 {
-                    Log("Updating", filePath);
+                    Log("Updating", filePath, EventType.Trace);
                     WriteFile(content, filePath);
                 }
             }
             else
             {
-                Log("Creating", filePath);
+                Log("Creating", filePath, EventType.Info);
                 _filesUtility.SafeCreateDirectory(Path.GetDirectoryName(filePath));
                 WriteFile(content, filePath);
             }
@@ -100,12 +100,12 @@ namespace Rhetos.Compiler
 
             foreach (var deleteFile in deleteFiles)
             {
-                Log("Deleting", deleteFile);
+                Log("Deleting", deleteFile, EventType.Info);
                 _filesUtility.SafeDeleteFile(deleteFile);
             }
         }
 
-        private void Log(string title, string filePath, EventType eventType = EventType.Info)
+        private void Log(string title, string filePath, EventType eventType)
         {
             _logger.Write(eventType, () => $"{title} '{FilesUtility.AbsoluteToRelativePath(_buildOptions.GeneratedSourceFolder, filePath)}'.");
         }

--- a/Source/Rhetos.Configuration.Autofac/ApplicationDeployment.cs
+++ b/Source/Rhetos.Configuration.Autofac/ApplicationDeployment.cs
@@ -43,7 +43,7 @@ namespace Rhetos
         /// <param name="pluginAssemblies">List of assemblies (DLL file paths) that will be scanned for plugins.</param>
         public ApplicationDeployment(IConfigurationProvider configurationProvider, ILogProvider logProvider, Func<IEnumerable<string>> pluginAssemblies)
         {
-            _logger = logProvider.GetLogger("DeployPackages");
+            _logger = logProvider.GetLogger(GetType().Name);
             _configurationProvider = configurationProvider;
             _logProvider = logProvider;
             _pluginAssemblies = pluginAssemblies;
@@ -52,7 +52,7 @@ namespace Rhetos
 
         public InstalledPackages DownloadPackages(bool ignoreDependencies)
         {
-            _logger.Trace("Getting packages.");
+            _logger.Info("Getting packages.");
             var config = new DeploymentConfiguration(_logProvider);
             var packageDownloaderOptions = new PackageDownloaderOptions { IgnorePackageDependencies = ignoreDependencies };
             var packageDownloader = new PackageDownloader(config, _logProvider, packageDownloaderOptions);
@@ -64,7 +64,7 @@ namespace Rhetos
 
         public void GenerateApplication(InstalledPackages installedPackages)
         {
-            _logger.Trace("Loading plugins.");
+            _logger.Info("Loading plugins.");
             var stopwatch = Stopwatch.StartNew();
 
             var builder = CreateBuildComponentsContainer(installedPackages);
@@ -95,7 +95,7 @@ namespace Rhetos
 
         public void UpdateDatabase()
         {
-            _logger.Trace("Loading plugins.");
+            _logger.Info("Loading plugins.");
             var stopwatch = Stopwatch.StartNew();
 
             var builder = CreateDbUpdateComponentsContainer();
@@ -126,7 +126,7 @@ namespace Rhetos
         {
             // Creating a new container builder instead of using builder.Update(), because of severe performance issues with the Update method.
 
-            _logger.Trace("Loading generated plugins.");
+            _logger.Info("Loading generated plugins.");
             var stopwatch = Stopwatch.StartNew();
 
             var builder = CreateAppInitializationComponentsContainer();
@@ -141,7 +141,7 @@ namespace Rhetos
 
                 if (!initializers.Any())
                 {
-                    _logger.Trace("No server initialization plugins.");
+                    _logger.Info("No server initialization plugins.");
                 }
                 else
                 {
@@ -180,9 +180,9 @@ namespace Rhetos
         {
             var configFile = Path.Combine(Paths.RhetosServerRootPath, "Web.config");
             if (FilesUtility.SafeTouch(configFile))
-                _logger.Trace($"Updated {Path.GetFileName(configFile)} modification date to restart server.");
+                _logger.Info($"Updated {Path.GetFileName(configFile)} modification date to restart server.");
             else
-                _logger.Trace($"Missing {configFile}.");
+                _logger.Info($"Missing {configFile}.");
         }
     }
 }

--- a/Source/Rhetos.DatabaseGenerator/ConceptDataMigrationExecuter.cs
+++ b/Source/Rhetos.DatabaseGenerator/ConceptDataMigrationExecuter.cs
@@ -30,7 +30,7 @@ namespace Rhetos.DatabaseGenerator
 {
     public class ConceptDataMigrationExecuter : IConceptDataMigrationExecuter
     {
-        private readonly ILogger _deployPackagesLogger;
+        private readonly ILogger _logger;
         private readonly SqlTransactionBatches _sqlExecuter;
         private readonly Lazy<GeneratedDataMigrationScripts> _scripts;
         private readonly RhetosAppEnvironment _rhetosAppEnvironment;
@@ -42,7 +42,7 @@ namespace Rhetos.DatabaseGenerator
             SqlTransactionBatches sqlExecuter,
             RhetosAppEnvironment rhetosAppEnvironment)
         {
-            _deployPackagesLogger = logProvider.GetLogger("DeployPackages");
+            _logger = logProvider.GetLogger("ConceptDataMigration");
             _sqlExecuter = sqlExecuter;
             _scripts = new Lazy<GeneratedDataMigrationScripts>(LoadScripts);
             _rhetosAppEnvironment = rhetosAppEnvironment;
@@ -50,7 +50,7 @@ namespace Rhetos.DatabaseGenerator
 
         public void ExecuteBeforeDataMigrationScripts()
         {
-            _deployPackagesLogger.Trace(() => $"Executing {_scripts.Value.BeforeDataMigration.Count()} before data migration scripts.");
+            _logger.Info(() => $"Executing {_scripts.Value.BeforeDataMigration.Count()} before-data-migration scripts.");
             _sqlExecuter.Execute(_scripts.Value.BeforeDataMigration.Select(x => 
                 new SqlTransactionBatches.SqlScript
                 {
@@ -61,7 +61,7 @@ namespace Rhetos.DatabaseGenerator
 
         public void ExecuteAfterDataMigrationScripts()
         {
-            _deployPackagesLogger.Trace(() => $"Executing {_scripts.Value.AfterDataMigration.Count()} after data migration scripts.");
+            _logger.Info(() => $"Executing {_scripts.Value.AfterDataMigration.Count()} after-data-migration scripts.");
             _sqlExecuter.Execute(_scripts.Value.AfterDataMigration.Reverse().Select(x =>
                 new SqlTransactionBatches.SqlScript
                 {

--- a/Source/Rhetos.DatabaseGenerator/DatabaseGenerator.cs
+++ b/Source/Rhetos.DatabaseGenerator/DatabaseGenerator.cs
@@ -37,8 +37,7 @@ namespace Rhetos.DatabaseGenerator
         private readonly IConceptApplicationRepository _conceptApplicationRepository;
         private readonly ILogger _logger;
 		/// <summary>Special logger for keeping track of inserted/updated/deleted concept applications in database.</summary>
-        private readonly ILogger _conceptsLogger;
-        private readonly ILogger _modifiedObjectsLogger;
+        private readonly ILogger _changesLogger;
         private readonly ILogger _performanceLogger;
         private readonly DatabaseGeneratorOptions _options;
         private readonly DatabaseModel _databaseModel;
@@ -52,9 +51,8 @@ namespace Rhetos.DatabaseGenerator
         {
             _sqlTransactionBatches = sqlTransactionBatches;
             _conceptApplicationRepository = conceptApplicationRepository;
-            _logger = logProvider.GetLogger("DatabaseGenerator");
-            _conceptsLogger = logProvider.GetLogger("DatabaseGenerator Concepts");
-            _modifiedObjectsLogger = logProvider.GetLogger("DatabaseGenerator ModifiedObjects");
+            _logger = logProvider.GetLogger(GetType().Name);
+            _changesLogger = logProvider.GetLogger("DatabaseGeneratorChanges");
             _performanceLogger = logProvider.GetLogger("Performance");
             _options = options;
             _databaseModel = databaseModel;
@@ -145,7 +143,7 @@ namespace Rhetos.DatabaseGenerator
                 .ToList();
 
             foreach (string ca in changedApplications)
-                _modifiedObjectsLogger.Trace(() => $"Changed concept application: {ca}\r\n{ReportDiff(oldApplicationsByKey[ca].CreateQuery, newApplicationsByKey[ca].CreateQuery)}");
+                _changesLogger.Trace(() => $"Changed concept application: {ca}\r\n{ReportDiff(oldApplicationsByKey[ca].CreateQuery, newApplicationsByKey[ca].CreateQuery)}");
 
             // Find dependent concepts applications to be regenerated:
 
@@ -330,7 +328,7 @@ namespace Rhetos.DatabaseGenerator
 
         private void LogDatabaseChanges(ConceptApplication conceptApplication, string action, Func<string> additionalInfo = null)
         {
-            _conceptsLogger.Trace("{0} {1}, ID={2}.{3}{4}",
+            _changesLogger.Trace("{0} {1}, ID={2}.{3}{4}",
                 action,
                 conceptApplication.GetConceptApplicationKey(),
                 SqlUtility.GuidToString(conceptApplication.Id),

--- a/Source/Rhetos.DatabaseGenerator/DatabaseGenerator.cs
+++ b/Source/Rhetos.DatabaseGenerator/DatabaseGenerator.cs
@@ -252,7 +252,7 @@ namespace Rhetos.DatabaseGenerator
                 newScripts.AddRange(MaybeCommitMetadataAfterDdl(removeSqlScripts));
             }
 
-            var logLevel = removedCACount > 0 ? EventType.Info : EventType.Trace;
+            var logLevel = removedCACount > 0 ? EventType.Warning : EventType.Info;
             _deployPackagesLogger.Write(logLevel, "DatabaseGenerator removing " + removedCACount + " concept applications.");
             return newScripts;
         }
@@ -278,7 +278,7 @@ namespace Rhetos.DatabaseGenerator
                 newScripts.AddRange(MaybeCommitMetadataAfterDdl(createSqlScripts));
             }
 
-            var logLevel = insertedCACount > 0 ? EventType.Info : EventType.Trace;
+            var logLevel = insertedCACount > 0 ? EventType.Warning : EventType.Info;
             _deployPackagesLogger.Write(logLevel, "DatabaseGenerator creating " + insertedCACount + " concept applications.");
             return newScripts;
         }

--- a/Source/Rhetos.DatabaseGenerator/DatabaseGenerator.cs
+++ b/Source/Rhetos.DatabaseGenerator/DatabaseGenerator.cs
@@ -39,7 +39,6 @@ namespace Rhetos.DatabaseGenerator
 		/// <summary>Special logger for keeping track of inserted/updated/deleted concept applications in database.</summary>
         private readonly ILogger _conceptsLogger;
         private readonly ILogger _modifiedObjectsLogger;
-        private readonly ILogger _deployPackagesLogger;
         private readonly ILogger _performanceLogger;
         private readonly DatabaseGeneratorOptions _options;
         private readonly DatabaseModel _databaseModel;
@@ -56,7 +55,6 @@ namespace Rhetos.DatabaseGenerator
             _logger = logProvider.GetLogger("DatabaseGenerator");
             _conceptsLogger = logProvider.GetLogger("DatabaseGenerator Concepts");
             _modifiedObjectsLogger = logProvider.GetLogger("DatabaseGenerator ModifiedObjects");
-            _deployPackagesLogger = logProvider.GetLogger("DeployPackages");
             _performanceLogger = logProvider.GetLogger("Performance");
             _options = options;
             _databaseModel = databaseModel;
@@ -253,7 +251,7 @@ namespace Rhetos.DatabaseGenerator
             }
 
             var logLevel = removedCACount > 0 ? EventType.Warning : EventType.Info;
-            _deployPackagesLogger.Write(logLevel, "DatabaseGenerator removing " + removedCACount + " concept applications.");
+            _logger.Write(logLevel, "Removing " + removedCACount + " concept applications.");
             return newScripts;
         }
 
@@ -279,7 +277,7 @@ namespace Rhetos.DatabaseGenerator
             }
 
             var logLevel = insertedCACount > 0 ? EventType.Warning : EventType.Info;
-            _deployPackagesLogger.Write(logLevel, "DatabaseGenerator creating " + insertedCACount + " concept applications.");
+            _logger.Write(logLevel, "Creating " + insertedCACount + " concept applications.");
             return newScripts;
         }
 

--- a/Source/Rhetos.DatabaseGenerator/DatabaseGenerator.cs
+++ b/Source/Rhetos.DatabaseGenerator/DatabaseGenerator.cs
@@ -248,8 +248,7 @@ namespace Rhetos.DatabaseGenerator
                 newScripts.AddRange(MaybeCommitMetadataAfterDdl(removeSqlScripts));
             }
 
-            var logLevel = removedCACount > 0 ? EventType.Warning : EventType.Info;
-            _logger.Write(logLevel, "Removing " + removedCACount + " concept applications.");
+            _logger.Info($"Removing {removedCACount} concept applications.");
             return newScripts;
         }
 
@@ -274,8 +273,7 @@ namespace Rhetos.DatabaseGenerator
                 newScripts.AddRange(MaybeCommitMetadataAfterDdl(createSqlScripts));
             }
 
-            var logLevel = insertedCACount > 0 ? EventType.Warning : EventType.Info;
-            _logger.Write(logLevel, "Creating " + insertedCACount + " concept applications.");
+            _logger.Info($"Creating {insertedCACount} concept applications.");
             return newScripts;
         }
 

--- a/Source/Rhetos.Deployment/ApplicationGenerator.cs
+++ b/Source/Rhetos.Deployment/ApplicationGenerator.cs
@@ -30,7 +30,7 @@ namespace Rhetos.Deployment
 {
     public class ApplicationGenerator
     {
-        private readonly ILogger _deployPackagesLogger;
+        private readonly ILogger _logger;
         private readonly IDslModel _dslModel;
         private readonly IPluginsContainer<IGenerator> _generatorsContainer;
         private readonly RhetosAppEnvironment _rhetosAppEnvironment;
@@ -47,7 +47,7 @@ namespace Rhetos.Deployment
             FilesUtility filesUtility,
             ISourceWriter sourceWriter)
         {
-            _deployPackagesLogger = logProvider.GetLogger("DeployPackages");
+            _logger = logProvider.GetLogger(GetType().Name);
             _dslModel = dslModel;
             _generatorsContainer = generatorsContainer;
             _rhetosAppEnvironment = rhetosAppEnvironment;
@@ -68,11 +68,11 @@ namespace Rhetos.Deployment
             var generators = GetSortedGenerators();
             foreach (var generator in generators)
             {
-                _deployPackagesLogger.Trace("Executing " + generator.GetType().Name + ".");
+                _logger.Info("Executing " + generator.GetType().Name + ".");
                 generator.Generate();
             }
             if (!generators.Any())
-                _deployPackagesLogger.Trace("No additional generators.");
+                _logger.Info("No additional generators.");
 
             if(!string.IsNullOrEmpty(_buildOptions.GeneratedSourceFolder))
                 _sourceWriter.CleanUp();
@@ -84,9 +84,9 @@ namespace Rhetos.Deployment
         /// </summary>
         private void CheckDslModelErrors()
         {
-            _deployPackagesLogger.Trace("Parsing DSL scripts.");
+            _logger.Info("Parsing DSL scripts.");
             int dslModelConceptsCount = _dslModel.Concepts.Count();
-            _deployPackagesLogger.Trace("Application model has " + dslModelConceptsCount + " statements.");
+            _logger.Info("Application model has " + dslModelConceptsCount + " statements.");
         }
 
         private IList<IGenerator> GetSortedGenerators()
@@ -105,7 +105,7 @@ namespace Rhetos.Deployment
             Graph.TopologicalSort(generatorNames, dependencies);
 
             foreach (var missingDependency in dependencies.Where(dep => !generatorNames.Contains(dep.Item1)))
-                _deployPackagesLogger.Warning($"Missing dependency '{missingDependency.Item1}' for application generator '{missingDependency.Item2}'.");
+                _logger.Warning($"Missing dependency '{missingDependency.Item1}' for application generator '{missingDependency.Item2}'.");
 
             Graph.SortByGivenOrder(generators, generatorNames, GetGeneratorName);
 

--- a/Source/Rhetos.Deployment/ApplicationGenerator.cs
+++ b/Source/Rhetos.Deployment/ApplicationGenerator.cs
@@ -105,7 +105,7 @@ namespace Rhetos.Deployment
             Graph.TopologicalSort(generatorNames, dependencies);
 
             foreach (var missingDependency in dependencies.Where(dep => !generatorNames.Contains(dep.Item1)))
-                _deployPackagesLogger.Info($"Missing dependency '{missingDependency.Item1}' for application generator '{missingDependency.Item2}'.");
+                _deployPackagesLogger.Warning($"Missing dependency '{missingDependency.Item1}' for application generator '{missingDependency.Item2}'.");
 
             Graph.SortByGivenOrder(generators, generatorNames, GetGeneratorName);
 

--- a/Source/Rhetos.Deployment/ApplicationInitialization.cs
+++ b/Source/Rhetos.Deployment/ApplicationInitialization.cs
@@ -24,9 +24,7 @@ using Rhetos.Persistence;
 using Rhetos.Utilities;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
 
 namespace Rhetos.Deployment
 {
@@ -58,13 +56,13 @@ namespace Rhetos.Deployment
         }
 
         /// <summary>
-        /// NOTE:
+        /// Note:
         /// This method does not conform to the standard IoC design pattern.
         /// It uses IoC container directly because it needs to handle a special scope control (separate database connections) and error handling.
         /// </summary>
         public static void ExecuteInitializer(IContainer container, Type initializerType)
         {
-            var deployPackagesLogger = container.Resolve<ILogProvider>().GetLogger("DeployPackages");
+            var logger = container.Resolve<ILogProvider>().GetLogger(nameof(ApplicationInitialization));
             
             Exception originalException = null;
             try
@@ -72,7 +70,7 @@ namespace Rhetos.Deployment
                 using (var initializerScope = container.BeginLifetimeScope())
                     try
                     {
-                        deployPackagesLogger.Trace("Initialization " + initializerType.Name + ".");
+                        logger.Info($"Initialization {initializerType.Name}.");
                         var initializers = initializerScope.Resolve<IPluginsContainer<IServerInitializer>>().GetPlugins();
                         IServerInitializer initializer = initializers.Single(i => i.GetType() == initializerType);
                         initializer.Initialize();
@@ -80,7 +78,7 @@ namespace Rhetos.Deployment
                     catch (Exception ex)
                     {
                         // Some exceptions result with invalid SQL transaction state that results with another exception on disposal of this 'using' block.
-                        // The original exception is logged here to make sure that it is not overridden;
+                        // The original exception is logged here to make sure that it is not overridden.
                         originalException = ex;
                         initializerScope.Resolve<IPersistenceTransaction>().DiscardChanges();
                         ExceptionsUtility.Rethrow(ex);
@@ -90,7 +88,7 @@ namespace Rhetos.Deployment
             {
                 if (originalException != null && ex != originalException)
                 {
-                    deployPackagesLogger.Error("Error on cleanup: " + ex.ToString());
+                    logger.Error($"Error on cleanup: {ex}");
                     ExceptionsUtility.Rethrow(originalException);
                 }
                 else

--- a/Source/Rhetos.Deployment/DataMigrationScriptsExecuter.cs
+++ b/Source/Rhetos.Deployment/DataMigrationScriptsExecuter.cs
@@ -72,7 +72,7 @@ namespace Rhetos.Deployment
                 if (_buildOptions.DataMigration__SkipScriptsWithWrongOrder)
                 {
                     // Ignore skipped scripts for backward compatibility.
-                    LogScripts("Skipped older script", skipped, EventType.Info);
+                    LogScripts("Skipped older script", skipped, EventType.Warning);
                     toExecute = toExecute.Except(skipped).ToList();
                     skippedReport = " " + skipped.Count + " older skipped.";
                 }
@@ -80,7 +80,7 @@ namespace Rhetos.Deployment
                 {
                     // Execute skipped scripts even though this means the scripts will be executed in the incorrect order.
                     // The message is logged as an *error* to increase the chance of being noticed because it is one-off event, even though it is not blocking.
-                    LogScripts("Executing script in an incorrect order", skipped, EventType.Info);
+                    LogScripts("Executing script in an incorrect order", skipped, EventType.Warning);
                 }
             }
 
@@ -111,10 +111,10 @@ namespace Rhetos.Deployment
 
         protected void ApplyToDatabase(List<DataMigrationScript> toRemove, List<DataMigrationScript> toExecute)
         {
-            LogScripts("Remove", toRemove, EventType.Info);
+            LogScripts("Remove", toRemove, EventType.Warning);
             Undo(toRemove.Select(s => s.Tag).ToList());
 
-            LogScripts("Execute", toExecute, EventType.Info);
+            LogScripts("Execute", toExecute, EventType.Warning);
             _sqlTransactionBatches.Execute(toExecute
                 .SelectMany(script => new[]
                 {

--- a/Source/Rhetos.Deployment/DataMigrationScriptsExecuter.cs
+++ b/Source/Rhetos.Deployment/DataMigrationScriptsExecuter.cs
@@ -106,10 +106,10 @@ namespace Rhetos.Deployment
 
         protected void ApplyToDatabase(List<DataMigrationScript> toRemove, List<DataMigrationScript> toExecute)
         {
-            LogScripts("Remove", toRemove, EventType.Warning);
+            LogScripts("Removing", toRemove, EventType.Info);
             Undo(toRemove.Select(s => s.Tag).ToList());
 
-            LogScripts("Execute", toExecute, EventType.Warning);
+            LogScripts("Executing", toExecute, EventType.Info);
             _sqlTransactionBatches.Execute(toExecute
                 .SelectMany(script => new[]
                 {

--- a/Source/Rhetos.Deployment/DatabaseCleaner.cs
+++ b/Source/Rhetos.Deployment/DatabaseCleaner.cs
@@ -26,14 +26,12 @@ namespace Rhetos.Deployment
 {
     public class DatabaseCleaner
     {
-        private readonly ISqlExecuter _sqlExecuter;
         private readonly ILogger _logger;
-        private readonly ILogger _deployPackagesLogger;
+        private readonly ISqlExecuter _sqlExecuter;
 
         public DatabaseCleaner(ILogProvider logProvider, ISqlExecuter sqlExecuter)
         {
-            _logger = logProvider.GetLogger("DatabaseCleaner");
-            _deployPackagesLogger = logProvider.GetLogger("DeployPackages");
+            _logger = logProvider.GetLogger(GetType().Name);
             _sqlExecuter = sqlExecuter;
         }
 
@@ -41,7 +39,7 @@ namespace Rhetos.Deployment
         {
             if (SqlUtility.DatabaseLanguage != "MsSql")
             {
-                var reportSkip = "Skipped DatabaseCleaner.DeleteAllMigrationData (DatabaseLanguage=" + SqlUtility.DatabaseLanguage + ").";
+                var reportSkip = "Skipped DeleteAllMigrationData (DatabaseLanguage=" + SqlUtility.DatabaseLanguage + ").";
                 _logger.Warning(reportSkip);
                 return reportSkip;
             }
@@ -59,7 +57,7 @@ namespace Rhetos.Deployment
         {
             if (SqlUtility.DatabaseLanguage != "MsSql")
             {
-                var reportSkip = "Skipped DatabaseCleaner.RefreshDataMigrationRows (DatabaseLanguage=" + SqlUtility.DatabaseLanguage + ").";
+                var reportSkip = "Skipped RefreshDataMigrationRows (DatabaseLanguage=" + SqlUtility.DatabaseLanguage + ").";
                 _logger.Warning(reportSkip);
                 return reportSkip;
             }
@@ -72,7 +70,7 @@ namespace Rhetos.Deployment
         {
             if (SqlUtility.DatabaseLanguage != "MsSql")
             {
-                _deployPackagesLogger.Warning("Skipped DatabaseCleaner.RemoveRedundantMigrationColumns (DatabaseLanguage=" + SqlUtility.DatabaseLanguage + ").");
+                _logger.Warning("Skipped RemoveRedundantMigrationColumns (DatabaseLanguage=" + SqlUtility.DatabaseLanguage + ").");
                 return;
             }
 
@@ -102,7 +100,7 @@ namespace Rhetos.Deployment
 
             DeleteDatabaseObjects(deleteMigrationColumnsOptimized, emptyMigrationTables, emptyMigrationSchemas);
 
-            _deployPackagesLogger.Trace(() =>
+            _logger.Info(() =>
                 "Deleted " + deleteMigrationColumns.Count + " columns in data migration schemas, "
                 + remainingMigrationColumns.Count + " remaining.");
         }

--- a/Source/Rhetos.Deployment/DatabaseCleaner.cs
+++ b/Source/Rhetos.Deployment/DatabaseCleaner.cs
@@ -42,7 +42,7 @@ namespace Rhetos.Deployment
             if (SqlUtility.DatabaseLanguage != "MsSql")
             {
                 var reportSkip = "Skipped DatabaseCleaner.DeleteAllMigrationData (DatabaseLanguage=" + SqlUtility.DatabaseLanguage + ").";
-                _logger.Info(reportSkip);
+                _logger.Warning(reportSkip);
                 return reportSkip;
             }
 
@@ -50,7 +50,7 @@ namespace Rhetos.Deployment
             var deleteMigrationSchemas = ReadDataMigrationSchemasFromDatabase();
             DeleteDatabaseObjects(new ColumnInfo[] { }, dataMigrationTables, deleteMigrationSchemas);
 
-            var report = "Deleted " + dataMigrationTables.Count() + " tables in data migration schemas.";
+            var report = $"Deleted {dataMigrationTables.Count} tables in data migration schemas.";
             _logger.Info(report);
             return report;
         }
@@ -60,7 +60,7 @@ namespace Rhetos.Deployment
             if (SqlUtility.DatabaseLanguage != "MsSql")
             {
                 var reportSkip = "Skipped DatabaseCleaner.RefreshDataMigrationRows (DatabaseLanguage=" + SqlUtility.DatabaseLanguage + ").";
-                _logger.Info(reportSkip);
+                _logger.Warning(reportSkip);
                 return reportSkip;
             }
 
@@ -72,7 +72,7 @@ namespace Rhetos.Deployment
         {
             if (SqlUtility.DatabaseLanguage != "MsSql")
             {
-                _deployPackagesLogger.Info("Skipped DatabaseCleaner.RemoveRedundantMigrationColumns (DatabaseLanguage=" + SqlUtility.DatabaseLanguage + ").");
+                _deployPackagesLogger.Warning("Skipped DatabaseCleaner.RemoveRedundantMigrationColumns (DatabaseLanguage=" + SqlUtility.DatabaseLanguage + ").");
                 return;
             }
 

--- a/Source/Rhetos.Deployment/DeploymentConfiguration.cs
+++ b/Source/Rhetos.Deployment/DeploymentConfiguration.cs
@@ -62,7 +62,7 @@ namespace Rhetos.Deployment
             if (requests.Any(r => string.IsNullOrEmpty(r.Id)))
                 throw new UserException($"Invalid configuration file format '{PackagesConfigurationFileName}'. Missing attribute 'id'.");
             if (requests.Count == 0)
-                _logger.Info($"Warning: No packages specified in '{PackagesConfigurationFileName}'. {configFileUsage}");
+                _logger.Warning($"Warning: No packages specified in '{PackagesConfigurationFileName}'. {configFileUsage}");
             Version dummy;
             // Simple version format in config file will be converted to a specific version "[ver,ver]", instead of being used as a minimal version (as in NuGet dependencies) in order to conform to NuGet packages.config convention.
             foreach (var request in requests)
@@ -81,7 +81,7 @@ namespace Rhetos.Deployment
                 .ToList();
 
             if (sources.Count == 0)
-                _logger.Info("No sources defined in '" + SourcesConfigurationFileName + "'. " + configFileUsage);
+                _logger.Warning("No sources defined in '" + SourcesConfigurationFileName + "'. " + configFileUsage);
             return sources;
         }
 

--- a/Source/Rhetos.Deployment/LoggerForNuget.cs
+++ b/Source/Rhetos.Deployment/LoggerForNuget.cs
@@ -18,16 +18,13 @@
 */
 
 using Rhetos.Logging;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Rhetos.Deployment
 {
     public class LoggerForNuget : NuGet.ILogger
     {
-        ILogger _logger;
+        readonly ILogger _logger;
 
         public LoggerForNuget(ILogProvider logProvider)
         {
@@ -37,7 +34,7 @@ namespace Rhetos.Deployment
         readonly Dictionary<NuGet.MessageLevel, EventType> logLevels = new Dictionary<NuGet.MessageLevel, EventType>
         {
             { NuGet.MessageLevel.Debug, EventType.Trace },
-            { NuGet.MessageLevel.Info, EventType.Trace },
+            { NuGet.MessageLevel.Info, EventType.Info },
             { NuGet.MessageLevel.Warning, EventType.Warning },
             { NuGet.MessageLevel.Error, EventType.Error },
         };

--- a/Source/Rhetos.Deployment/LoggerForNuget.cs
+++ b/Source/Rhetos.Deployment/LoggerForNuget.cs
@@ -34,11 +34,11 @@ namespace Rhetos.Deployment
             _logger = logProvider.GetLogger("NuGet");
         }
 
-        Dictionary<NuGet.MessageLevel, EventType> logLevels = new Dictionary<NuGet.MessageLevel, EventType>
+        readonly Dictionary<NuGet.MessageLevel, EventType> logLevels = new Dictionary<NuGet.MessageLevel, EventType>
         {
             { NuGet.MessageLevel.Debug, EventType.Trace },
             { NuGet.MessageLevel.Info, EventType.Trace },
-            { NuGet.MessageLevel.Warning, EventType.Info },
+            { NuGet.MessageLevel.Warning, EventType.Warning },
             { NuGet.MessageLevel.Error, EventType.Error },
         };
 

--- a/Source/Rhetos.Deployment/PackageDownloader.cs
+++ b/Source/Rhetos.Deployment/PackageDownloader.cs
@@ -39,7 +39,6 @@ namespace Rhetos.Deployment
         private readonly DeploymentConfiguration _deploymentConfiguration;
         private readonly ILogProvider _logProvider;
         private readonly Rhetos.Logging.ILogger _logger;
-        private readonly Rhetos.Logging.ILogger _packagesLogger;
         private readonly Rhetos.Logging.ILogger _performanceLogger;
         private readonly PackageDownloaderOptions _options;
         private readonly FilesUtility _filesUtility;
@@ -52,8 +51,7 @@ namespace Rhetos.Deployment
         {
             _deploymentConfiguration = deploymentConfiguration;
             _logProvider = logProvider;
-            _logger = logProvider.GetLogger(GetType().Name);
-            _packagesLogger = logProvider.GetLogger("Packages");
+            _logger = logProvider.GetLogger("Packages");
             _performanceLogger = logProvider.GetLogger("Performance");
             _options = options;
             _filesUtility = new FilesUtility(logProvider);
@@ -101,9 +99,6 @@ namespace Rhetos.Deployment
             SortByDependencies(installedPackages);
 
             binFileSyncer.UpdateDestination();
-
-            foreach (var package in installedPackages)
-                _packagesLogger.Trace(() => package.Report());
 
             _performanceLogger.Write(sw, "PackageDownloader.GetPackages.");
 

--- a/Source/Rhetos.Deployment/PackageDownloader.cs
+++ b/Source/Rhetos.Deployment/PackageDownloader.cs
@@ -240,19 +240,19 @@ namespace Rhetos.Deployment
             }
             else if (existingMetadataFiles.Length > 1)
             {
-                _logger.Info(() => "Package " + request.Id + " source folder '" + source.ProvidedLocation + "' contains multiple .nuspec metadata files.");
+                _logger.Warning(() => $"Package {request.Id} source folder '{source.ProvidedLocation}' contains multiple .nuspec metadata files.");
                 return null;
             }
             else if (existingMetadataFiles.Length == 1)
             {
-                _logger.Trace(() => "Reading package " + request.Id + " from unpacked source folder with metadata " + Path.GetFileName(existingMetadataFiles.Single()) + ".");
-                _deployPackagesLogger.Trace(() => "Reading " + request.Id + " from source.");
+                _logger.Trace(() => $"Reading package {request.Id} from unpacked source folder with metadata {Path.GetFileName(existingMetadataFiles.Single())}.");
+                _deployPackagesLogger.Trace(() => $"Reading {request.Id} from source.");
                 return UseFilesFromUnpackedSourceWithMetadata(existingMetadataFiles.Single(), request, binFileSyncer);
             }
             else if (existingSourceSubfolders.Any())
             {
-                _logger.Trace(() => "Reading package " + request.Id + " from unpacked source folder without metadata file.");
-                _deployPackagesLogger.Trace(() => "Reading " + request.Id + " from source without metadata.");
+                _logger.Trace(() => $"Reading package {request.Id} from unpacked source folder without metadata file.");
+                _deployPackagesLogger.Trace(() => $"Reading {request.Id} from source without metadata.");
                 return UseFilesFromUnpackedSourceWithoutMetadata(source.Path, request, binFileSyncer);
             }
             else

--- a/Source/Rhetos.Deployment/PackageDownloader.cs
+++ b/Source/Rhetos.Deployment/PackageDownloader.cs
@@ -41,7 +41,6 @@ namespace Rhetos.Deployment
         private readonly Rhetos.Logging.ILogger _logger;
         private readonly Rhetos.Logging.ILogger _packagesLogger;
         private readonly Rhetos.Logging.ILogger _performanceLogger;
-        private readonly Rhetos.Logging.ILogger _deployPackagesLogger;
         private readonly PackageDownloaderOptions _options;
         private readonly FilesUtility _filesUtility;
         private readonly string _packagesCacheFolder;
@@ -56,7 +55,6 @@ namespace Rhetos.Deployment
             _logger = logProvider.GetLogger(GetType().Name);
             _packagesLogger = logProvider.GetLogger("Packages");
             _performanceLogger = logProvider.GetLogger("Performance");
-            _deployPackagesLogger = logProvider.GetLogger("DeployPackages");
             _options = options;
             _filesUtility = new FilesUtility(logProvider);
             _packagesCacheFolder = Path.Combine(Paths.RhetosServerRootPath, "PackagesCache");
@@ -246,13 +244,13 @@ namespace Rhetos.Deployment
             else if (existingMetadataFiles.Length == 1)
             {
                 _logger.Trace(() => $"Reading package {request.Id} from unpacked source folder with metadata {Path.GetFileName(existingMetadataFiles.Single())}.");
-                _deployPackagesLogger.Trace(() => $"Reading {request.Id} from source.");
+                _logger.Info(() => $"Reading {request.Id} from source.");
                 return UseFilesFromUnpackedSourceWithMetadata(existingMetadataFiles.Single(), request, binFileSyncer);
             }
             else if (existingSourceSubfolders.Any())
             {
                 _logger.Trace(() => $"Reading package {request.Id} from unpacked source folder without metadata file.");
-                _deployPackagesLogger.Trace(() => $"Reading {request.Id} from source without metadata.");
+                _logger.Info(() => $"Reading {request.Id} from source without metadata.");
                 return UseFilesFromUnpackedSourceWithoutMetadata(source.Path, request, binFileSyncer);
             }
             else
@@ -372,7 +370,7 @@ namespace Rhetos.Deployment
             }
 
             _logger.Trace(() => $"Reading package {request.Id} from legacy file {zipPackagePath}.");
-            _deployPackagesLogger.Trace(() => $"Reading {request.Id} from legacy zip file.");
+            _logger.Info(() => $"Reading {request.Id} from legacy zip file.");
 
             string targetFolder = GetTargetFolder(request.Id, zipPackage.Version);
             _filesUtility.EmptyDirectory(targetFolder);
@@ -448,7 +446,7 @@ namespace Rhetos.Deployment
 
             string packageSubfolder = nugetRepository.PathResolver.GetPackageDirectory(request.Id, package.Version);
             _logger.Trace(() => $"Reading package {request.Id} from cache '{packageSubfolder}'.");
-            _deployPackagesLogger.Trace(() => $"Reading {request.Id} from cache.");
+            _logger.Info(() => $"Reading {request.Id} from cache.");
             string targetFolder = Path.Combine(_packagesCacheFolder, packageSubfolder);
 
             foreach (var file in FilterCompatibleLibFiles(package.GetFiles()))

--- a/Source/Rhetos.Deployment/ResourcesGenerator.cs
+++ b/Source/Rhetos.Deployment/ResourcesGenerator.cs
@@ -36,14 +36,14 @@ namespace Rhetos.Deployment
     {
         private readonly InstalledPackages _installedPackages;
         private readonly ILogProvider _logProvider;
-        private readonly ILogger _deployPackagesLogger;
+        private readonly ILogger _logger;
         private readonly ILogger _performanceLogger;
 
         public ResourcesGenerator(InstalledPackages installedPackages, ILogProvider logProvider, BuildOptions buildOptions)
         {
             _installedPackages = installedPackages;
             _logProvider = logProvider;
-            _deployPackagesLogger = logProvider.GetLogger("DeployPackages");
+            _logger = logProvider.GetLogger(GetType().Name);
             _performanceLogger = logProvider.GetLogger("Performance");
         }
 
@@ -78,7 +78,7 @@ namespace Rhetos.Deployment
             foreach (var file in resourceFiles)
                 _fileSyncer.AddFile(file.Source, Paths.ResourcesFolder, file.Target);
 
-            _deployPackagesLogger.Trace($"ResourcesGenerator: Copying {resourceFiles.Count} resource files.");
+            _logger.Info($"Copying {resourceFiles.Count} resource files.");
             _fileSyncer.UpdateDestination();
 
             _performanceLogger.Write(stopwatch, "ResourcesGenerator.");

--- a/Source/Rhetos.Dsl/DslModel.cs
+++ b/Source/Rhetos.Dsl/DslModel.cs
@@ -378,7 +378,7 @@ namespace Rhetos.Dsl
                 .ToList();
 
             foreach (var conceptsGroup in obsoleteConceptsByUserReport)
-                _logger.Info(() => string.Format("Obsolete concept {0} ({1} occurrences). {2}",
+                _logger.Warning(() => string.Format("Obsolete concept {0} ({1} occurrences). {2}",
                     conceptsGroup.Concepts.First().GetUserDescription(),
                     conceptsGroup.Concepts.Count(),
                     conceptsGroup.ObsoleteMessage));

--- a/Source/Rhetos.Dsl/DslParser.cs
+++ b/Source/Rhetos.Dsl/DslParser.cs
@@ -171,7 +171,7 @@ namespace Rhetos.Dsl
                 if (_legacySyntax.Value == LegacySyntax.Ignore)
                     _logger.Trace(warning);
                 else
-                    _logger.Info(warning);
+                    _logger.Warning(warning);
             }
             if (_legacySyntax.Value == LegacySyntax.Error && warnings.Any())
                 throw new DslSyntaxException(warnings.First());

--- a/Source/Rhetos.Extensibility/PluginScanner.cs
+++ b/Source/Rhetos.Extensibility/PluginScanner.cs
@@ -98,7 +98,7 @@ namespace Rhetos.Extensibility
             foreach (var duplicate in byFilename.Where(dll => dll.paths.Count > 1))
             {
                 var otherPaths = string.Join(", ", duplicate.paths.Skip(1).Select(path => $"'{path}'"));
-                _logger.Info($"Multiple paths for '{duplicate.filename}' found. This causes ambiguous DLL loading and can cause type errors. Loaded: '{duplicate.paths.First()}', ignored: {otherPaths}.");
+                _logger.Warning($"Multiple paths for '{duplicate.filename}' found. This causes ambiguous DLL loading and can cause type errors. Loaded: '{duplicate.paths.First()}', ignored: {otherPaths}.");
             }
 
             var namesToPaths = byFilename.ToDictionary(dll => dll.filename, dll => dll.paths.First(), StringComparer.InvariantCultureIgnoreCase);
@@ -229,7 +229,7 @@ namespace Rhetos.Extensibility
             var actualFile = new FileInfo(actualPath);
 
             if (requestedFile.Length != actualFile.Length || requestedFile.LastWriteTimeUtc != actualFile.LastWriteTimeUtc)
-                _logger.Info($"Assembly at requested path '{requestedPath}' is not the same as loaded assembly at '{actualPath}'. This can cause issues with types.");
+                _logger.Warning($"Assembly at requested path '{requestedPath}' is not the same as loaded assembly at '{actualPath}'. This can cause issues with types.");
             else
                 _logger.Trace($"Same assembly loaded from '{actualPath}' instead of '{requestedPath}'.");
         }

--- a/Source/Rhetos.Extensibility/PluginScanner.cs
+++ b/Source/Rhetos.Extensibility/PluginScanner.cs
@@ -228,10 +228,23 @@ namespace Rhetos.Extensibility
             var requestedFile = new FileInfo(requestedPath);
             var actualFile = new FileInfo(actualPath);
 
-            if (requestedFile.Length != actualFile.Length || requestedFile.LastWriteTimeUtc != actualFile.LastWriteTimeUtc)
+            if (requestedFile.Length != actualFile.Length || !SameTimeIgnoreTimeZone(requestedFile.LastWriteTimeUtc, actualFile.LastWriteTimeUtc))
                 _logger.Warning($"Assembly at requested path '{requestedPath}' is not the same as loaded assembly at '{actualPath}'. This can cause issues with types.");
             else
                 _logger.Trace($"Same assembly loaded from '{actualPath}' instead of '{requestedPath}'.");
+        }
+
+        /// <summary>
+        /// Simplified heuristics to ignore file timezone errors, because NuGet pack/unpack can shift last modified time: https://github.com/NuGet/Home/issues/7395
+        /// This method does not need to be exact, because it's purpose is only to reduce clutter in log.
+        /// </summary>
+        private bool SameTimeIgnoreTimeZone(DateTime lastWriteTimeUtc1, DateTime lastWriteTimeUtc2)
+        {
+            return
+                lastWriteTimeUtc1.Subtract(lastWriteTimeUtc2).TotalHours <= 14
+                && lastWriteTimeUtc1.Minute == lastWriteTimeUtc2.Minute
+                && lastWriteTimeUtc1.Second == lastWriteTimeUtc2.Second
+                && lastWriteTimeUtc1.Millisecond == lastWriteTimeUtc2.Millisecond;
         }
 
         private static Dictionary<Type, List<PluginInfo>> GetMefExportsForTypes(Type[] types)

--- a/Source/Rhetos.Logging.Interfaces/ILogger.cs
+++ b/Source/Rhetos.Logging.Interfaces/ILogger.cs
@@ -18,10 +18,7 @@
 */
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using System.Globalization;
 
 namespace Rhetos.Logging
@@ -29,13 +26,18 @@ namespace Rhetos.Logging
     public enum EventType
     {
         /// <summary>
-        /// Very detailed logs, which may include high-volume information such as protocol payloads. This log level is typically only enabled during development.
+        /// Very detailed logs, which may include high-volume information such as protocol payloads.
+        /// This log level is typically only enabled for debugging.
         /// </summary>
         Trace,
         /// <summary>
-        /// Information messages and warnings, which are normally enabled in production environment.
+        /// Information messages, which are normally enabled in production environment and kept permanently.
         /// </summary>
         Info,
+        /// <summary>
+        /// Warning messages, which are normally enabled in production environment and kept permanently.
+        /// </summary>
+        Warning,
         /// <summary>
         /// Error messages, which are normally sent to administrator in production environment.
         /// </summary>
@@ -45,6 +47,7 @@ namespace Rhetos.Logging
     public interface ILogger
     {
         void Write(EventType eventType, Func<string> logMessage);
+
         /// <summary>
         /// Returns the logger name that was provided as argument for <see cref="ILogProvider.GetLogger(string)"/>.
         /// </summary>
@@ -66,7 +69,7 @@ namespace Rhetos.Logging
         private static void PerformanceWrite(this ILogger performanceLogger, Stopwatch stopwatch, Func<string> fullMessage)
         {
             if (stopwatch.Elapsed >= SlowEvent)
-                performanceLogger.Info(fullMessage);
+                performanceLogger.Warning(fullMessage);
             else
                 performanceLogger.Trace(fullMessage);
             stopwatch.Restart();
@@ -97,6 +100,14 @@ namespace Rhetos.Logging
         public static void Error(this ILogger log, Func<string> logMessage)
         {
             log.Write(EventType.Error, logMessage);
+        }
+        public static void Warning(this ILogger log, string eventData, params object[] eventDataParams)
+        {
+            log.Write(EventType.Warning, eventData, eventDataParams);
+        }
+        public static void Warning(this ILogger log, Func<string> logMessage)
+        {
+            log.Write(EventType.Warning, logMessage);
         }
         public static void Info(this ILogger log, string eventData, params object[] eventDataParams)
         {

--- a/Source/Rhetos.Logging/NLogger.cs
+++ b/Source/Rhetos.Logging/NLogger.cs
@@ -36,14 +36,21 @@ namespace Rhetos.Logging
 
         public void Write(EventType eventType, Func<string> logMessage)
         {
-            LogMessageGenerator logMessageGenerator = () => logMessage();
-
-            if (eventType == EventType.Info)
-                Logger.Info(logMessageGenerator);
-            else if (eventType == EventType.Error)
-                Logger.Error(logMessageGenerator);
-            else
-                Logger.Trace(logMessageGenerator);
+            switch (eventType)
+            {
+                case EventType.Trace:
+                    Logger.Trace(() => logMessage());
+                    break;
+                case EventType.Info:
+                    Logger.Info(() => logMessage());
+                    break;
+                case EventType.Warning:
+                    Logger.Warn(() => logMessage());
+                    break;
+                default:
+                    Logger.Error(() => logMessage());
+                    break;
+            }
         }
 
         public string Name => Logger.Name;

--- a/Source/Rhetos.Persistence/PersistenceTransaction.cs
+++ b/Source/Rhetos.Persistence/PersistenceTransaction.cs
@@ -73,7 +73,7 @@ namespace Rhetos.Persistence
         public void CommitAndReconnect()
         {
             string callerInfo = GetCaller();
-            _logger.Info(() => "CommitAndReconnect is obsolete. Please upgrade to a latest version of the Rhetos plugin '" + callerInfo + "'.");
+            _logger.Warning(() => "CommitAndReconnect is obsolete. Please upgrade to a latest version of the Rhetos plugin '" + callerInfo + "'.");
 
             if (_disposed)
                 throw new FrameworkException("Trying to commit and reconnect a disposed persistence transaction.");

--- a/Source/Rhetos.Processing/ProcessingEngine.cs
+++ b/Source/Rhetos.Processing/ProcessingEngine.cs
@@ -215,7 +215,7 @@ namespace Rhetos.Processing
                 : logException is UserException ? EventType.Trace
                 : logException is ClientException ? EventType.Info
                 : EventType.Error;
-                 
+            
             _logger.Write(errorSeverity, () => logError + (string.IsNullOrEmpty(logError) ? "" : " ") + logException);
 
             var result = new ProcessingResult

--- a/Source/Rhetos.Security/NullAuthorizationProvider.cs
+++ b/Source/Rhetos.Security/NullAuthorizationProvider.cs
@@ -43,7 +43,7 @@ namespace Rhetos.Security
 
         public IList<bool> GetAuthorizations(IUserInfo userInfo, IList<Claim> requiredClaims)
         {
-            _logger.Info("There is no authorization package installed. Deploy the necessary Rhetos package (for example, CommonConcepts).");
+            _logger.Warning("There is no authorization package installed. Deploy the necessary Rhetos package (for example, CommonConcepts).");
 
             return requiredClaims.Select(c => false).ToList();
         }

--- a/Source/Rhetos.Utilities.Test/EventTypeTest.cs
+++ b/Source/Rhetos.Utilities.Test/EventTypeTest.cs
@@ -32,7 +32,7 @@ namespace Rhetos.Utilities.Test
         [TestMethod]
         public void Order()
         {
-            var eventsOrderedByLevel = new[] { EventType.Trace, EventType.Info, EventType.Error };
+            var eventsOrderedByLevel = new[] { EventType.Trace, EventType.Info, EventType.Warning, EventType.Error };
 
             Assert.AreEqual(
                 Enum.GetValues(typeof(EventType)).Length,

--- a/Source/Rhetos.Utilities.Test/FilesUtilityTest.cs
+++ b/Source/Rhetos.Utilities.Test/FilesUtilityTest.cs
@@ -73,7 +73,7 @@ namespace Rhetos.Utilities.Test
             var log = new List<string>();
             LogMonitor logMonitor = (eventType, eventName, message) =>
             {
-                if (eventName == "FilesUtility" && eventType == Logging.EventType.Info)
+                if (eventName == "FilesUtility" && eventType == Logging.EventType.Warning)
                     log.Add($"{message}");
             };
 
@@ -105,7 +105,7 @@ namespace Rhetos.Utilities.Test
             var log = new List<string>();
             LogMonitor logMonitor = (eventType, eventName, message) =>
             {
-                if (eventName == "FilesUtility" && eventType == Logging.EventType.Info)
+                if (eventName == "FilesUtility" && eventType == Logging.EventType.Warning)
                     log.Add($"{message()}");
             };
 

--- a/Source/Rhetos.Utilities/FileSyncer.cs
+++ b/Source/Rhetos.Utilities/FileSyncer.cs
@@ -175,9 +175,9 @@ namespace Rhetos.Utilities
                     if (newestInGroup.Length != otherFile.Length)
                         _logger.Error("Conflicting source files with different file size: '{0}' and '{1}'.", newestInGroup.FullName, otherFile.FullName);
                     else if (newestInGroup.LastWriteTime != otherFile.LastWriteTime)
-                        _logger.Info("Conflicting source files with different modification time: '{0}' and '{1}'.", newestInGroup.FullName, otherFile.FullName);
+                        _logger.Warning("Conflicting source files with different modification time: '{0}' and '{1}'.", newestInGroup.FullName, otherFile.FullName);
                     else
-                        _logger.Info("Duplicate source files ignored: '{0}' and '{1}'.", newestInGroup.FullName, otherFile.FullName);
+                        _logger.Warning("Duplicate source files ignored: '{0}' and '{1}'.", newestInGroup.FullName, otherFile.FullName);
 
                     if (otherFile.LastWriteTime > newestInGroup.LastWriteTime
                         || otherFile.LastWriteTime == newestInGroup.LastWriteTime && otherFile.Length > newestInGroup.Length)

--- a/Source/Rhetos.Utilities/FilesUtility.cs
+++ b/Source/Rhetos.Utilities/FilesUtility.cs
@@ -19,7 +19,6 @@
 
 using Rhetos.Logging;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -50,8 +49,10 @@ namespace Rhetos.Utilities
                     if (tries <= 1)
                         throw;
 
-                    if (tries == maxTries - 1) // Logging the second retry instead of the first one, because first retries are too common.
-                        _logger.Trace(() => "Waiting to " + actionName.Invoke() + ".");
+                    if (tries == maxTries) // First retries are very common on some environments.
+                        _logger.Trace(() => $"Waiting to {actionName.Invoke()}.");
+                    if (tries == maxTries - 1) // Second retry is often result of a locked file.
+                        _logger.Warning(() => $"Waiting to {actionName.Invoke()}.");
 
                     System.Threading.Thread.Sleep(500);
                 }
@@ -68,7 +69,7 @@ namespace Rhetos.Utilities
             }
             catch (Exception ex)
             {
-                throw new FrameworkException(String.Format("Can't create directory '{0}'. Check that it's not locked.", path), ex);
+                throw new FrameworkException($"Can't create directory '{path}'. Check that it's not locked.", ex);
             }
         }
 
@@ -93,7 +94,7 @@ namespace Rhetos.Utilities
             }
             catch (Exception ex)
             {
-                throw new FrameworkException(String.Format("Can't delete directory '{0}'. Check that it's not locked.", path), ex);
+                throw new FrameworkException($"Can't delete directory '{path}'. Check that it's not locked.", ex);
             }
         }
 
@@ -120,7 +121,7 @@ namespace Rhetos.Utilities
             }
             catch (Exception ex)
             {
-                throw new FrameworkException(String.Format("Can't move file '{0}' to '{1}'. Check that destination file or folder is not locked.", source, destination), ex);
+                throw new FrameworkException($"Can't move file '{source}' to '{destination}'. Check that destination file or folder is not locked.", ex);
             }
         }
 
@@ -138,7 +139,7 @@ namespace Rhetos.Utilities
             }
             catch (Exception ex)
             {
-                throw new FrameworkException(String.Format("Can't copy file '{0}' to '{1}'. Check that destination folder is not locked.", sourceFile, destinationFile), ex);
+                throw new FrameworkException($"Can't copy file '{sourceFile}' to '{destinationFile}'. Check that destination folder is not locked.", ex);
             }
         }
 

--- a/Source/Rhetos.Utilities/FilesUtility.cs
+++ b/Source/Rhetos.Utilities/FilesUtility.cs
@@ -175,7 +175,7 @@ namespace Rhetos.Utilities
             {
                 bool tryDefault = !Encoding.Default.Equals(Encoding.UTF8);
 
-                _logger.Info($"WARNING: File '{path}' contains invalid UTF-8 character at line {ScriptPositionReporting.Line(text, invalidCharIndex)}." +
+                _logger.Warning($"Warning: File '{path}' contains invalid UTF-8 character at line {ScriptPositionReporting.Line(text, invalidCharIndex)}." +
                     (tryDefault ? $" Reading with default system encoding instead." : "") +
                     $" Save text file as UTF-8.");
 

--- a/Source/RhetosCli/App.config
+++ b/Source/RhetosCli/App.config
@@ -20,41 +20,25 @@
   </runtime>
   <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" throwExceptions="true">
     <targets>
-      <target name="MainLog" xsi:type="File" fileName="${basedir}\..\Logs\DeployPackages.log" encoding="utf-8"
-        archiveFileName="${basedir}\..\Logs\Archives\DeployPackages {#####}.zip" enableArchiveFileCompression="true" archiveAboveSize="2000000" archiveNumbering="DateAndSequence" />
       <target name="ConsoleLog" xsi:type="ColoredConsole" layout="[${level}] ${logger}: ${message}">
         <highlight-row condition="level == LogLevel.Error" foregroundColor="Red" backgroundColor="Black"/>
-        <highlight-row condition="level == LogLevel.Info" foregroundColor="Yellow" backgroundColor="Black"/>
-        <highlight-row condition="level == LogLevel.Trace" foregroundColor="Gray" backgroundColor="Black"/>
+        <highlight-row condition="level == LogLevel.Warn" foregroundColor="Yellow" backgroundColor="Black"/>
+        <highlight-row condition="level == LogLevel.Info" foregroundColor="Gray" backgroundColor="Black"/>
+        <highlight-row condition="level == LogLevel.Trace" foregroundColor="DarkGray" backgroundColor="Black"/>
+      </target>
+      <target name="MainLog" xsi:type="File" fileName="${basedir}\..\Logs\RhetosCli.log" encoding="utf-8"
+        archiveFileName="${basedir}\..\Logs\Archives\RhetosCli {#####}.zip" enableArchiveFileCompression="true" archiveAboveSize="2000000" archiveNumbering="DateAndSequence" />
+      <target name="PerformanceLog" xsi:type="AsyncWrapper" overflowAction="Block">
+        <target name="PerformanceLogBase" xsi:type="File" fileName="${basedir}\..\Logs\RhetosCliPerformance.log" encoding="utf-8" deleteOldFileOnStartup="true"/>
       </target>
       <target name="TraceLog" xsi:type="AsyncWrapper" overflowAction="Block">
-        <target name="TraceLogBase" xsi:type="File" fileName="${basedir}\..\Logs\DeployPackagesTrace.log" encoding="utf-8" deleteOldFileOnStartup="true"/>
+        <target name="TraceLogBase" xsi:type="File" fileName="${basedir}\..\Logs\RhetosCliTrace.log" encoding="utf-8" deleteOldFileOnStartup="true"/>
       </target>
-      <target name="PerformanceLog" xsi:type="AsyncWrapper" overflowAction="Block">
-        <target name="PerformanceLogBase" xsi:type="File" fileName="${basedir}\..\Logs\DeployPackagesPerformance.log" encoding="utf-8" deleteOldFileOnStartup="true"/>
-      </target>
-      <target name="KeywordsLog" xsi:type="File" fileName="${basedir}\..\Logs\DeployPackagesKeywords.log" encoding="utf-8" deleteOldFileOnStartup="true"/>
-      <target name="MacroEvaluatorsOrderLog" xsi:type="File" fileName="${basedir}\..\Logs\DeployPackagesMacroEvaluatorsOrder.log" encoding="utf-8" deleteOldFileOnStartup="true"/>
     </targets>
     <rules>
-      <logger name="*" minLevel="Info" writeTo="MainLog"/>
-      <logger name="AssemblyGenerator" level="Trace" writeTo="MainLog"/>
-      <logger name="ClaimGenerator Claims" level="Trace" writeTo="MainLog"/>
-      <logger name="DatabaseGenerator Concepts" level="Trace" writeTo="MainLog"/>
-      <logger name="DatabaseGenerator ModifiedObjects" level="Trace" writeTo="MainLog"/>
-      <logger name="DeployPackages" level="Trace" writeTo="MainLog"/>
-      <logger name="FileSyncer" level="Trace" writeTo="MainLog"/>
-      <logger name="NuGet" level="Trace" writeTo="MainLog"/>
-      <logger name="PackageDownloader" level="Trace" writeTo="MainLog"/>
-      <logger name="Packages" level="Trace" writeTo="MainLog"/>
-      <logger name="AfterDeploy" level="Trace" writeTo="MainLog"/>
       <logger name="*" minLevel="Info" writeTo="ConsoleLog"/>
-      <logger name="AssemblyGenerator" level="Trace" writeTo="ConsoleLog"/>
-      <logger name="DeployPackages" level="Trace" writeTo="ConsoleLog"/>
-      <logger name="FilesUtility" level="Trace" writeTo="ConsoleLog"/>
-      <logger name="NuGet" level="Trace" writeTo="ConsoleLog"/>
-      <logger name="DslParser.Keywords" minLevel="Trace" writeTo="KeywordsLog"/>
-      <!-- <logger name="MacroEvaluatorsOrder" minLevel="Trace" writeTo="MacroEvaluatorsOrderLog"/> -->
+      <logger name="*" minLevel="Info" writeTo="MainLog"/>
+      <logger name="DatabaseGeneratorChanges" level="Trace" writeTo="MainLog"/>
       <logger name="Performance" minLevel="Trace" writeTo="PerformanceLog"/>
       <!-- <logger name="*" minLevel="Trace" writeTo="TraceLog"/> -->
     </rules>

--- a/Source/RhetosCli/App.config
+++ b/Source/RhetosCli/App.config
@@ -21,10 +21,10 @@
   <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" throwExceptions="true">
     <targets>
       <target name="ConsoleLog" xsi:type="ColoredConsole" layout="[${level}] ${logger}: ${message}">
-        <highlight-row condition="level == LogLevel.Error" foregroundColor="Red" backgroundColor="Black"/>
-        <highlight-row condition="level == LogLevel.Warn" foregroundColor="Yellow" backgroundColor="Black"/>
-        <highlight-row condition="level == LogLevel.Info" foregroundColor="Gray" backgroundColor="Black"/>
-        <highlight-row condition="level == LogLevel.Trace" foregroundColor="DarkGray" backgroundColor="Black"/>
+        <highlight-row condition="level == LogLevel.Error" foregroundColor="Red" backgroundColor="NoChange"/>
+        <highlight-row condition="level == LogLevel.Warn" foregroundColor="Yellow" backgroundColor="NoChange"/>
+        <highlight-row condition="level == LogLevel.Info" foregroundColor="NoChange" backgroundColor="NoChange"/>
+        <highlight-row condition="level == LogLevel.Trace" foregroundColor="DarkGray" backgroundColor="NoChange"/>
       </target>
       <target name="MainLog" xsi:type="File" fileName="${basedir}\..\Logs\RhetosCli.log" encoding="utf-8"
         archiveFileName="${basedir}\..\Logs\Archives\RhetosCli {#####}.zip" enableArchiveFileCompression="true" archiveAboveSize="2000000" archiveNumbering="DateAndSequence" />

--- a/Source/RhetosCli/Program.cs
+++ b/Source/RhetosCli/Program.cs
@@ -20,13 +20,11 @@
 using Rhetos.Logging;
 using Rhetos.Utilities;
 using System;
-using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.CommandLine;
-using System.CommandLine.Invocation;
-using Rhetos.Deployment;
 
 namespace Rhetos
 {
@@ -43,12 +41,12 @@ namespace Rhetos
         public Program()
         {
             LogProvider = new NLogProvider();
-            Logger = LogProvider.GetLogger("DeployPackages");
+            Logger = LogProvider.GetLogger("Rhetos");
         }
 
         public int Run(string[] args)
         {
-            Logger.Trace(() => "Logging configured.");
+            Logger.Info(() => "Logging configured.");
 
             var rootCommand = new RootCommand();
             var buildCommand = new Command("build", "Generates the Rhetos application inside the <project-root-folder>. If <project-root-folder> is not set it will use the current working directory.");
@@ -74,7 +72,7 @@ namespace Rhetos
             try
             {
                 action.Invoke();
-                Logger.Trace("Done.");
+                Logger.Info("Done.");
             }
             catch (Exception e)
             {

--- a/Source/RhetosCli/Program.cs
+++ b/Source/RhetosCli/Program.cs
@@ -97,7 +97,7 @@ namespace Rhetos
 
             string binFolder = Path.Combine(projectRootPath, "bin");
             if (FilesUtility.IsSameDirectory(AppDomain.CurrentDomain.BaseDirectory, binFolder))
-                throw new FrameworkException($"Rhetos build command cannot be run from the generated application.");
+                throw new FrameworkException($"Rhetos build command cannot be run from the generated application. Visual Studio integration runs it automatically from Rhetos NuGet package tools folder. You can run it manually from Package Manager Console, because it is included in PATH.");
 
             var configurationProvider = new ConfigurationBuilder()
                 .AddRhetosAppEnvironment(new RhetosAppEnvironment

--- a/Source/RhetosVSIntegration/NuGetLogger.cs
+++ b/Source/RhetosVSIntegration/NuGetLogger.cs
@@ -39,7 +39,7 @@ namespace Rhetos
             { LogLevel.Verbose, MessageImportance.Low },
             { LogLevel.Information, MessageImportance.Normal },
             { LogLevel.Minimal, MessageImportance.Normal },
-            { LogLevel.Warning, MessageImportance.Normal },
+            { LogLevel.Warning, MessageImportance.High },
             { LogLevel.Error, MessageImportance.High },
         };
 
@@ -47,25 +47,24 @@ namespace Rhetos
         {
             if (level == LogLevel.Error)
                 _logger.LogError(data);
+            else if (level == LogLevel.Warning)
+                _logger.LogWarning(data);
             else
                 _logger.LogMessage(_levelMapping[level], data);
         }
 
         public void Log(ILogMessage message)
         {
-            if (message.Level == LogLevel.Error)
-                _logger.LogError(message.ToString());
-            else
-                _logger.LogMessage(_levelMapping[message.Level], message.ToString());
+            Log(message.Level, message.ToString());
         }
 
-    public System.Threading.Tasks.Task LogAsync(LogLevel level, string data) => new System.Threading.Tasks.Task(() => Log(level, data));
+        public System.Threading.Tasks.Task LogAsync(LogLevel level, string data) => new System.Threading.Tasks.Task(() => Log(level, data));
 
         public System.Threading.Tasks.Task LogAsync(ILogMessage message) => new System.Threading.Tasks.Task(() => Log(message));
 
         public void LogDebug(string data) => Log(LogLevel.Debug, data);
 
-        public void LogError(string data) => Log(LogLevel.Error, data);
+        public void LogVerbose(string data) => Log(LogLevel.Verbose, data);
 
         public void LogInformation(string data) => Log(LogLevel.Information, data);
 
@@ -73,8 +72,8 @@ namespace Rhetos
 
         public void LogMinimal(string data) => Log(LogLevel.Minimal, data);
 
-        public void LogVerbose(string data) => Log(LogLevel.Verbose, data);
-
         public void LogWarning(string data) => Log(LogLevel.Warning, data);
+
+        public void LogError(string data) => Log(LogLevel.Error, data);
     }
 }

--- a/Source/RhetosVSIntegration/NuGetUtilities.cs
+++ b/Source/RhetosVSIntegration/NuGetUtilities.cs
@@ -87,7 +87,7 @@ namespace Rhetos
                 installedPackages.Add(new InstalledPackage(library.Name, library.Version.Version.ToString(), dependencies, packageFolder, null, null, contentFiles));
             }
             
-            var sortedPackages =  SortInstalledPackagesByDependencies(targetLibraries, installedPackages);
+            var sortedPackages = SortInstalledPackagesByDependencies(targetLibraries, installedPackages);
             sortedPackages.Add(GetProjectAsInstalledPackage());
             return sortedPackages;
         }

--- a/Source/RhetosVSIntegration/ResolveRhetosProjectAssets.cs
+++ b/Source/RhetosVSIntegration/ResolveRhetosProjectAssets.cs
@@ -49,7 +49,7 @@ namespace RhetosVSIntegration
                 OutputAssemblyName = AssemblyName
             };
 
-            new RhetosProjectAssetsFileProvider(ProjectDirectory, new RhetosLogProvider(Log)).Save(rhetosProjectAssets);
+            new RhetosProjectAssetsFileProvider(ProjectDirectory, new VSLogProvider(Log)).Save(rhetosProjectAssets);
 
             return true;
         }

--- a/Source/RhetosVSIntegration/RhetosVSIntegration.csproj
+++ b/Source/RhetosVSIntegration/RhetosVSIntegration.csproj
@@ -48,7 +48,7 @@
     <Compile Include="..\Rhetos\Properties\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="RhetosLogProvider.cs" />
+    <Compile Include="VSLogProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core">


### PR DESCRIPTION
* Simplified logging rules. The log output is almost same as before, but now it is all controlled by setting the logging level.
Currently the only exception is DatabaseGeneratorChanges log: It is too detailed for console, but it should be persisted in log file for later analysis of deployment issues.
* Removed "DeployPackages" loggers, using Info logging level instead.
* New logging level: Warning. Most Info messages changed to Warnings.
* Using new NuGet for Rhetos framework packages, to resolve issue with modified file timestamps on old NuGet CLI. This will reduce "different assembly" warnings from Rhetos package scanner.
* Console log colors consistent with MSBuild.