### PR TITLE
Plugin scanner optimization

### DIFF
--- a/Source/Rhetos.Configuration.Autofac/RhetosContainerBuilder.cs
+++ b/Source/Rhetos.Configuration.Autofac/RhetosContainerBuilder.cs
@@ -44,7 +44,12 @@ namespace Rhetos
         {
             this.RegisterInstance(configurationProvider);
 
-            var pluginScanner = new PluginScanner(pluginAssemblies, configurationProvider.GetOptions<BuildOptions>(), configurationProvider.GetOptions<RhetosAppEnvironment>(), logProvider);
+            var pluginScanner = new PluginScanner(
+                pluginAssemblies,
+                configurationProvider.GetOptions<BuildOptions>(),
+                configurationProvider.GetOptions<RhetosAppEnvironment>(),
+                logProvider,
+                configurationProvider.GetOptions<PluginScannerOptions>());
 
             // make properties accessible to modules which are provided with new/unique instance of ContainerBuilder
             this.Properties.Add(nameof(IPluginScanner), pluginScanner);

--- a/Source/Rhetos.Extensibility.Test/PluginScannerTest.cs
+++ b/Source/Rhetos.Extensibility.Test/PluginScannerTest.cs
@@ -37,7 +37,7 @@ namespace Rhetos.Extensibility.Test
         public void AnalyzeAndReportTypeLoadException()
         {
             IEnumerable<string> findAssemblies() => new[] { GetIncompatibleAssemblyPath() };
-            var pluginsScanner = new PluginScanner(findAssemblies, null, new RhetosAppEnvironment { AssetsFolder = "." }, new ConsoleLogProvider());
+            var pluginsScanner = new PluginScanner(findAssemblies, null, new RhetosAppEnvironment { AssetsFolder = "." }, new ConsoleLogProvider(), new PluginScannerOptions());
 
             TestUtility.ShouldFail<FrameworkException>(
                 () => pluginsScanner.FindPlugins(typeof(IGenerator)),

--- a/Source/Rhetos.Extensibility/PluginScanner.cs
+++ b/Source/Rhetos.Extensibility/PluginScanner.cs
@@ -40,12 +40,14 @@ namespace Rhetos.Extensibility
         private readonly ILogger _performanceLogger;
         private readonly PluginScannerCache _pluginScannerCache;
         private static readonly object _pluginsCacheLock = new object();
+        private readonly HashSet<string> _ignoreAssemblyFiles;
+        private readonly string[] _ignoreAssemblyPrefixes;
 
         /// <summary>
         /// It searches for type implementations in the provided list of assemblies.
         /// </summary>
-        /// <param name="findAssemblies">The findAssemblies function should return a list of DLL file paths that will be searched for plugins when invoking the method <see cref="PluginScanner.FindPlugins"/></param>
-        public PluginScanner(Func<IEnumerable<string>> findAssemblies, BuildOptions buildOptions, RhetosAppEnvironment rhetosAppEnvironment, ILogProvider logProvider)
+        /// <param name="findAssemblies">The findAssemblies function should return a list of DLL file paths that will be searched for plugins when invoking the method <see cref="FindPlugins"/></param>
+        public PluginScanner(Func<IEnumerable<string>> findAssemblies, BuildOptions buildOptions, RhetosAppEnvironment rhetosAppEnvironment, ILogProvider logProvider, PluginScannerOptions pluginScannerOptions)
         {
             _pluginsByExport = new Lazy<MultiDictionary<string, PluginInfo>>(
                 () => GetPluginsByExport(findAssemblies),
@@ -53,6 +55,10 @@ namespace Rhetos.Extensibility
             _pluginScannerCache = new PluginScannerCache(buildOptions, rhetosAppEnvironment, logProvider, new FilesUtility(logProvider));
             _performanceLogger = logProvider.GetLogger("Performance");
             _logger = logProvider.GetLogger(GetType().Name);
+
+            var ignoreList = pluginScannerOptions.PredefinedIgnoreAssemblyFiles.Concat(pluginScannerOptions.IgnoreAssemblyFiles ?? Array.Empty<string>()).Distinct().ToList();
+            _ignoreAssemblyFiles = new HashSet<string>(ignoreList.Where(name => !name.EndsWith("*")), StringComparer.OrdinalIgnoreCase);
+            _ignoreAssemblyPrefixes = ignoreList.Where(name => name.EndsWith("*")).Select(name => name.Trim('*')).ToArray();
         }
 
         /// <summary>
@@ -102,12 +108,11 @@ namespace Rhetos.Extensibility
             }
 
             var namesToPaths = byFilename.ToDictionary(dll => dll.filename, dll => dll.paths.First(), StringComparer.InvariantCultureIgnoreCase);
-            ResolveEventHandler resolver = (sender, args) => LoadAssemblyFromSpecifiedPaths(sender, args, namesToPaths);
 
-            return resolver;
+            return (sender, args) => LoadAssemblyFromSpecifiedPaths(args, namesToPaths);
         }
 
-        private Assembly LoadAssemblyFromSpecifiedPaths(object sender, ResolveEventArgs args, Dictionary<string, string> namesToPaths)
+        private Assembly LoadAssemblyFromSpecifiedPaths(ResolveEventArgs args, Dictionary<string, string> namesToPaths)
         {
             var filename = $"{new AssemblyName(args.Name).Name}.dll";
             if (namesToPaths.TryGetValue(filename, out var path))
@@ -123,7 +128,11 @@ namespace Rhetos.Extensibility
         {
             var stopwatch = Stopwatch.StartNew();
 
-            var assemblies = findAssemblies().Select(path => Path.GetFullPath(path)).Distinct().ToList();
+            var assemblies = findAssemblies()
+                .Select(path => (Path: path, Name: Path.GetFileName(path)))
+                .Where(file => !_ignoreAssemblyFiles.Contains(file.Name) && !_ignoreAssemblyPrefixes.Any(prefix => file.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
+                .Select(file => Path.GetFullPath(file.Path))
+                .Distinct().ToList();
 
             foreach (var assembly in assemblies)
                 if (!File.Exists(assembly))

--- a/Source/Rhetos.Extensibility/PluginScanner.cs
+++ b/Source/Rhetos.Extensibility/PluginScanner.cs
@@ -228,23 +228,10 @@ namespace Rhetos.Extensibility
             var requestedFile = new FileInfo(requestedPath);
             var actualFile = new FileInfo(actualPath);
 
-            if (requestedFile.Length != actualFile.Length || !SameTimeIgnoreTimeZone(requestedFile.LastWriteTimeUtc, actualFile.LastWriteTimeUtc))
+            if (requestedFile.Length != actualFile.Length || !requestedFile.LastWriteTimeUtc.Equals(actualFile.LastWriteTimeUtc))
                 _logger.Warning($"Assembly at requested path '{requestedPath}' is not the same as loaded assembly at '{actualPath}'. This can cause issues with types.");
             else
                 _logger.Trace($"Same assembly loaded from '{actualPath}' instead of '{requestedPath}'.");
-        }
-
-        /// <summary>
-        /// Simplified heuristics to ignore file timezone errors, because NuGet pack/unpack can shift last modified time: https://github.com/NuGet/Home/issues/7395
-        /// This method does not need to be exact, because it's purpose is only to reduce clutter in log.
-        /// </summary>
-        private bool SameTimeIgnoreTimeZone(DateTime lastWriteTimeUtc1, DateTime lastWriteTimeUtc2)
-        {
-            return
-                lastWriteTimeUtc1.Subtract(lastWriteTimeUtc2).TotalHours <= 14
-                && lastWriteTimeUtc1.Minute == lastWriteTimeUtc2.Minute
-                && lastWriteTimeUtc1.Second == lastWriteTimeUtc2.Second
-                && lastWriteTimeUtc1.Millisecond == lastWriteTimeUtc2.Millisecond;
         }
 
         private static Dictionary<Type, List<PluginInfo>> GetMefExportsForTypes(Type[] types)

--- a/Source/Rhetos.Extensibility/PluginScannerOptions.cs
+++ b/Source/Rhetos.Extensibility/PluginScannerOptions.cs
@@ -1,0 +1,75 @@
+﻿/*
+    Copyright (C) 2014 Omega software d.o.o.
+
+    This file is part of Rhetos.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using System.Collections.Generic;
+
+namespace Rhetos.Extensibility
+{
+    public class PluginScannerOptions
+    {
+        /// <summary>
+        /// List of file names or file name prefixes that will be ignored when scanning for plugins.
+        /// If an entry ends with '*', it will be considered a file name prefix, otherwise an exact match will be used.
+        /// Names are case-insensitive.
+        /// These entries will be appended to <see cref="PredefinedIgnoreAssemblyFiles"/>.
+        /// </summary>
+        public IEnumerable<string> IgnoreAssemblyFiles { get; set; }
+
+        public IEnumerable<string> PredefinedIgnoreAssemblyFiles { get; set; } = _predefinedIgnoreAssemblyFiles;
+
+        private static readonly IEnumerable<string> _predefinedIgnoreAssemblyFiles = new[]
+        {
+            "Autofac.*",
+            "EntityFramework.*",
+            "Microsoft.*",
+            "NuGet.*",
+            "System.*",
+            "Newtonsoft.Json.dll",
+            "NLog.dll",
+            "Oracle.ManagedDataAccess.dll",
+            "Rhetos.Compiler.dll",
+            "Rhetos.Compiler.Interfaces.dll",
+            "Rhetos.Configuration.Autofac.dll",
+            "Rhetos.DatabaseGenerator.dll",
+            "Rhetos.DatabaseGenerator.Interfaces.dll",
+            "Rhetos.Deployment.dll",
+            "Rhetos.Deployment.Interfaces.dll",
+            "Rhetos.Dom.dll",
+            "Rhetos.Dom.Interfaces.dll",
+            "Rhetos.Dsl.dll",
+            "Rhetos.Dsl.Interfaces.dll",
+            "Rhetos.Extensibility.dll",
+            "Rhetos.Extensibility.Interfaces.dll",
+            "Rhetos.Interfaces.dll",
+            "Rhetos.Logging.dll",
+            "Rhetos.Logging.Interfaces.dll",
+            "Rhetos.Persistence.dll",
+            "Rhetos.Persistence.Interfaces.dll",
+            "Rhetos.Processing.dll",
+            "Rhetos.Processing.Interfaces.dll",
+            "Rhetos.Security.dll",
+            "Rhetos.Security.Interfaces.dll",
+            "Rhetos.TestCommon.dll",
+            "Rhetos.Utilities.dll",
+            "Rhetos.Web.dll",
+            "Rhetos.XmlSerialization.dll",
+            "RhetosVSIntegration.dll",
+        };
+    }
+}

--- a/Source/Rhetos.Extensibility/Rhetos.Extensibility.csproj
+++ b/Source/Rhetos.Extensibility/Rhetos.Extensibility.csproj
@@ -131,6 +131,7 @@
     <Compile Include="IPluginScanner.cs" />
     <Compile Include="PluginInfo.cs" />
     <Compile Include="NamedPlugins.cs" />
+    <Compile Include="PluginScannerOptions.cs" />
     <Compile Include="PluginsContainer.cs" />
     <Compile Include="PluginsMetadataCache.cs" />
     <Compile Include="ContainerBuilderPluginRegistration.cs" />

--- a/Source/RhetosCli/Program.cs
+++ b/Source/RhetosCli/Program.cs
@@ -97,7 +97,9 @@ namespace Rhetos
 
             string binFolder = Path.Combine(projectRootPath, "bin");
             if (FilesUtility.IsSameDirectory(AppDomain.CurrentDomain.BaseDirectory, binFolder))
-                throw new FrameworkException($"Rhetos build command cannot be run from the generated application. Visual Studio integration runs it automatically from Rhetos NuGet package tools folder. You can run it manually from Package Manager Console, because it is included in PATH.");
+                throw new FrameworkException($"Rhetos build command cannot be run from the generated application folder." +
+                    $" Visual Studio integration runs it automatically from Rhetos NuGet package tools folder." +
+                    $" You can run it manually from Package Manager Console, it is included in PATH.");
 
             var configurationProvider = new ConfigurationBuilder()
                 .AddRhetosAppEnvironment(new RhetosAppEnvironment


### PR DESCRIPTION
Ignoring certain assemblies when scanning for Rhetos plugins.

* This improves performance, but also removes some rhetos-build warnings for different 3rd party assemblies that are included in Rhetos framework (NuGet timestamp issues).
* The ignore list is configurable, and contains some predefined assemblies that are part of the Rhetos framework.