### PR TITLE
Sorting concepts and plugins

### DIFF
--- a/Source/Rhetos.Dsl.Test/DslContainerTest.cs
+++ b/Source/Rhetos.Dsl.Test/DslContainerTest.cs
@@ -20,11 +20,9 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Rhetos.TestCommon;
 using Rhetos.Utilities;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 
 namespace Rhetos.Dsl.Test
 {
@@ -33,10 +31,9 @@ namespace Rhetos.Dsl.Test
     {
         class DslContainerAccessor : DslContainer
         {
-            public DslContainerAccessor(IConfigurationProvider configuration = null)
+            public DslContainerAccessor()
                 : base(new ConsoleLogProvider(),
-                      new MockPluginsContainer<IDslModelIndex>(new DslModelIndexByType()),
-                      configuration ?? new ConfigurationBuilder().Build())
+                      new MockPluginsContainer<IDslModelIndex>(new DslModelIndexByType()))
             {
             }
 
@@ -47,7 +44,7 @@ namespace Rhetos.Dsl.Test
                     return (List<IConceptInfo>)typeof(DslContainer)
                         .GetField("_resolvedConcepts", BindingFlags.NonPublic | BindingFlags.Instance)
                         .GetValue(this);
-        }
+                }
                 set
                 {
                     typeof(DslContainer)
@@ -234,31 +231,26 @@ namespace Rhetos.Dsl.Test
             var testData = new List<IConceptInfo> { c02, c01, cB2, c2Dependant, cInit, c03, cB1 };
 
             // The expected positions may somewhat change if the sorting algorithm internals change.
-            var tests = new List<(string SortMethod, List<IConceptInfo> ExpectedResult)>
+            var tests = new List<(InitialConceptsSort SortMethod, List<IConceptInfo> ExpectedResult)>
             {
                 // cInit always goes first. cDependant does not need to move because it is after referenced c1 and c5.
-                ( "None", new List<IConceptInfo> { cInit, c02, c01, cB2, c2Dependant, c03, cB1 } ),
+                ( InitialConceptsSort.None, new List<IConceptInfo> { cInit, c02, c01, cB2, c2Dependant, c03, cB1 } ),
 
                 // cB2 is pushed before c2Dependant, to respect dependency precedence.
-                ( "Key", new List<IConceptInfo> { cInit, c01, c02, c03, cB2, c2Dependant, cB1 } ),
+                ( InitialConceptsSort.Key, new List<IConceptInfo> { cInit, c01, c02, c03, cB2, c2Dependant, cB1 } ),
 
                 // c01 is pushed before c2Dependant, to respect dependency precedence.
-                ( "KeyDescending", new List<IConceptInfo> { cInit, cB2, cB1, c01, c2Dependant, c03, c02 } ),
+                ( InitialConceptsSort.KeyDescending, new List<IConceptInfo> { cInit, cB2, cB1, c01, c2Dependant, c03, c02 } ),
             };
 
             foreach (var test in tests)
             {
-                var configuration = new ConfigurationBuilder()
-                    .AddKeyValue("CommonConcepts.Debug.SortConcepts", test.SortMethod.ToString())
-                    .Build();
-
-                var dslContainer = new DslContainerAccessor(configuration);
-                dslContainer.ResolvedConcepts = testData;
-                dslContainer.SortReferencesBeforeUsingConcept();
+                var dslContainer = new DslContainerAccessor { ResolvedConcepts = testData };
+                dslContainer.SortReferencesBeforeUsingConcept(test.SortMethod);
                 Assert.AreEqual(
                     TestUtility.Dump(test.ExpectedResult, c => c.GetKey()),
                     TestUtility.Dump(dslContainer.ResolvedConcepts, c => c.GetKey()),
-                    test.SortMethod);
+                    $"SortConceptsMethod: {test.SortMethod}");
             }
         }
     }

--- a/Source/Rhetos.Dsl.Test/DslModelTest.cs
+++ b/Source/Rhetos.Dsl.Test/DslModelTest.cs
@@ -111,7 +111,7 @@ namespace Rhetos.Dsl.Test
 
         static IDslModel NewDslModel(IDslParser parser, IEnumerable<IConceptInfo> conceptPrototypes)
         {
-            var dslContainter = new DslContainer(new ConsoleLogProvider(), new MockPluginsContainer<IDslModelIndex>(new DslModelIndexByType()), new ConfigurationBuilder().Build());
+            var dslContainter = new DslContainer(new ConsoleLogProvider(), new MockPluginsContainer<IDslModelIndex>(new DslModelIndexByType()));
             var dslModel = new DslModel(
                 parser,
                 new ConsoleLogProvider(),
@@ -120,7 +120,8 @@ namespace Rhetos.Dsl.Test
                 new IConceptMacro[] { },
                 conceptPrototypes,
                 new StubMacroOrderRepository(),
-                new StubDslModelFile());
+                new StubDslModelFile(),
+                new BuildOptions());
             return dslModel;
         }
 

--- a/Source/Rhetos.Dsl.Test/Mocks/MockPluginsContainer.cs
+++ b/Source/Rhetos.Dsl.Test/Mocks/MockPluginsContainer.cs
@@ -20,14 +20,12 @@
 using Rhetos.Extensibility;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Rhetos.Dsl.Test
 {
     public class MockPluginsContainer<T> : IPluginsContainer<T>
     {
-        IEnumerable<T> _plugins;
+        readonly IEnumerable<T> _plugins;
 
         public MockPluginsContainer(params T[] plugins)
         {

--- a/Source/Rhetos.Dsl/DslContainer.cs
+++ b/Source/Rhetos.Dsl/DslContainer.cs
@@ -24,7 +24,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 
 namespace Rhetos.Dsl
 {
@@ -46,8 +45,6 @@ namespace Rhetos.Dsl
         private readonly MultiDictionary<string, UnresolvedReference> _unresolvedConceptsByReference = new MultiDictionary<string, UnresolvedReference>();
         private readonly List<IDslModelIndex> _dslModelIndexes;
         private readonly Dictionary<Type, IDslModelIndex> _dslModelIndexesByType;
-        private readonly SortConceptsMethod _sortConceptsMethod;
-        private enum SortConceptsMethod { None, Key, KeyDescending };
 
         private class ConceptDescription
         {
@@ -80,13 +77,12 @@ namespace Rhetos.Dsl
             }
         }
 
-        public DslContainer(ILogProvider logProvider, IPluginsContainer<IDslModelIndex> dslModelIndexPlugins, IConfigurationProvider configurationProvider)
+        public DslContainer(ILogProvider logProvider, IPluginsContainer<IDslModelIndex> dslModelIndexPlugins)
         {
             _performanceLogger = logProvider.GetLogger("Performance");
             _logger = logProvider.GetLogger("DslContainer");
             _dslModelIndexes = dslModelIndexPlugins.GetPlugins().ToList();
             _dslModelIndexesByType = _dslModelIndexes.ToDictionary(index => index.GetType());
-            _sortConceptsMethod = configurationProvider.GetValue("CommonConcepts.Debug.SortConcepts", SortConceptsMethod.None);
         }
 
         #region IDslModel filters implementation
@@ -328,7 +324,7 @@ namespace Rhetos.Dsl
                         $"Unresolved dependency to '{u.ReferencedKey}' <= '{u.Dependant.Concept.GetUserDescription()}',"
                         + $" {u.Member.Name} = '{u.ReferencedStub.GetUserDescription()}' ({u.Dependant.UnresolvedDependencies} left)")));
 
-                var internalError = unresolvedConcepts.Where(u => u.Dependant.UnresolvedDependencies <= 0).FirstOrDefault();
+                var internalError = unresolvedConcepts.FirstOrDefault(u => u.Dependant.UnresolvedDependencies <= 0);
                 if (internalError != null)
                     throw new FrameworkException($"Internal error while resolving references of '{internalError.Dependant.Concept.GetUserDescription()}'."
                         + $" The concept has {internalError.Dependant.UnresolvedDependencies} unresolved dependencies,"
@@ -349,8 +345,7 @@ namespace Rhetos.Dsl
                 return unresolved;
 
             var referencedUnresolvedConcept = _unresolvedConceptsByReference.SelectMany(ucbr => ucbr.Value)
-                .Where(u => u.Dependant.Key == unresolved.ReferencedKey)
-                .FirstOrDefault();
+                .FirstOrDefault(u => u.Dependant.Key == unresolved.ReferencedKey);
 
             if (referencedUnresolvedConcept == null)
                 throw new FrameworkException($"Internal error when resolving concept's references: '{unresolved.Dependant.Concept.GetUserDescription()}' has unresolved reference to '{unresolved.ReferencedStub.GetUserDescription()}', but the referenced concept is not marked as unresolved.");
@@ -374,24 +369,22 @@ namespace Rhetos.Dsl
         /// This will allow code generators to safely assume that the code for referenced concept B
         /// is already generated before the concept A inserts an additional code snippet into it.
         /// </summary>
-        public void SortReferencesBeforeUsingConcept()
+        public void SortReferencesBeforeUsingConcept(InitialConceptsSort initialSort)
         {
             var sw = Stopwatch.StartNew();
 
-            if (_sortConceptsMethod != SortConceptsMethod.None)
+            if (initialSort != InitialConceptsSort.None)
             {
                 // Initial sorting will reduce variations in the generated application source
                 // that are created by different macro evaluation order on each deployment.
-                var sortComparison = new Dictionary<SortConceptsMethod, Comparison<IConceptInfo>>
+                var sortComparison = new Dictionary<InitialConceptsSort, Comparison<IConceptInfo>>
                 {
-                    { SortConceptsMethod.Key, (a, b) => a.GetKey().CompareTo(b.GetKey()) },
-                    // Descending option can be used in testing (along with ascending sort) to detect missing dependencies between concepts
-                    // (code generators might fail with "script does not contain tag", update of empty database might fail with missing column, e.g.).
-                    { SortConceptsMethod.KeyDescending, (a, b) => -a.GetKey().CompareTo(b.GetKey()) },
+                    { InitialConceptsSort.Key, (a, b) => a.GetKey().CompareTo(b.GetKey()) },
+                    { InitialConceptsSort.KeyDescending, (a, b) => -a.GetKey().CompareTo(b.GetKey()) },
                 };
 
-                _resolvedConcepts.Sort(sortComparison[_sortConceptsMethod]);
-                _performanceLogger.Write(sw, $"DslContainer.SortReferencesBeforeUsingConcept: Initial sort by {_sortConceptsMethod}.");
+                _resolvedConcepts.Sort(sortComparison[initialSort]);
+                _performanceLogger.Write(sw, $"DslContainer.SortReferencesBeforeUsingConcept: Initial sort by {initialSort}.");
             }
 
             List<IConceptInfo> sortedList = new List<IConceptInfo>(_resolvedConcepts.Count);

--- a/Source/Rhetos.Dsl/DslModel.cs
+++ b/Source/Rhetos.Dsl/DslModel.cs
@@ -43,6 +43,7 @@ namespace Rhetos.Dsl
         private readonly IEnumerable<Type> _conceptTypes;
         private readonly IMacroOrderRepository _macroOrderRepository;
         private readonly IDslModelFile _dslModelFile;
+        private readonly BuildOptions _buildOptions;
 
         public DslModel(
             IDslParser dslParser,
@@ -52,7 +53,8 @@ namespace Rhetos.Dsl
             IEnumerable<IConceptMacro> macroPrototypes,
             IEnumerable<IConceptInfo> conceptPrototypes,
             IMacroOrderRepository macroOrderRepository,
-            IDslModelFile dslModelFile)
+            IDslModelFile dslModelFile,
+            BuildOptions buildOptions)
         {
             _dslParser = dslParser;
             _performanceLogger = logProvider.GetLogger("Performance");
@@ -64,6 +66,7 @@ namespace Rhetos.Dsl
             _conceptTypes = conceptPrototypes.Select(conceptInfo => conceptInfo.GetType());
             _macroOrderRepository = macroOrderRepository;
             _dslModelFile = dslModelFile;
+            _buildOptions = buildOptions;
         }
 
         #region IDslModel implementation
@@ -88,7 +91,7 @@ namespace Rhetos.Dsl
             ExpandMacroConcepts(dslContainer);
             dslContainer.ReportErrorForUnresolvedConcepts();
             CheckSemantics(dslContainer);
-            dslContainer.SortReferencesBeforeUsingConcept();
+            dslContainer.SortReferencesBeforeUsingConcept(_buildOptions.CommonConcepts__Debug__SortConcepts);
             ReportObsoleteConcepts(dslContainer);
             _dslModelFile.SaveConcepts(dslContainer.Concepts);
 

--- a/Source/Rhetos.Extensibility/PluginsContainer.cs
+++ b/Source/Rhetos.Extensibility/PluginsContainer.cs
@@ -18,20 +18,18 @@
 */
 
 using Autofac.Features.Indexed;
-using Autofac.Features.Metadata;
 using Rhetos.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Rhetos.Extensibility
 {
     public class PluginsContainer<TPlugin> : IPluginsContainer<TPlugin>
     {
-        private Lazy<IEnumerable<TPlugin>> _sortedPlugins;
-        private Lazy<IIndex<Type, IEnumerable<TPlugin>>> _pluginsByImplementation;
-        private PluginsMetadataCache<TPlugin> _cache;
+        private readonly Lazy<IEnumerable<TPlugin>> _sortedPlugins;
+        private readonly Lazy<IIndex<Type, IEnumerable<TPlugin>>> _pluginsByImplementation;
+        private readonly PluginsMetadataCache<TPlugin> _cache;
 
         public PluginsContainer(
             Lazy<IEnumerable<TPlugin>> plugins,

--- a/Source/Rhetos.Utilities/BuildOptions.cs
+++ b/Source/Rhetos.Utilities/BuildOptions.cs
@@ -31,5 +31,13 @@ namespace Rhetos.Utilities
         public bool DataMigration__SkipScriptsWithWrongOrder { get; set; } = true;
         public bool CommonConcepts__Legacy__AutoGeneratePolymorphicProperty { get; set; } = true;
         public bool CommonConcepts__Legacy__CascadeDeleteInDatabase { get; set; } = true;
+        public InitialConceptsSort CommonConcepts__Debug__SortConcepts { get; set; } = InitialConceptsSort.Key; // TODO: Rename property to Dsl__InitialConceptsSort. This feature is part of Rhetos framework, not CommonConcepts.
     }
+
+    /// <summary>
+    /// Initial sorting will reduce variations in the generated application source
+    /// that are created by different macro evaluation order on each deployment.
+    /// Changing the sort method can be used to test if correct dependencies are specified for code generators or for database objects.
+    /// </summary>
+    public enum InitialConceptsSort { None, Key, KeyDescending };
 }


### PR DESCRIPTION
Concept and plugins are pre-sorted, before sorting by dependencies, to reduce volatility of generated code where dependencies are not specified.

This might cause existing project to fail because of missing dependencies that were not detected earlier:
errors on database update because of incorrect order of created object, and errors for missing tag in code generators.
You can suppress this issues by setting this build option to None (e.g. `<add key="CommonConcepts.Debug.SortConcepts" value="None" />`).