### PR TITLE
Canonical error format

### DIFF
--- a/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/InvalidDataTest.cs
+++ b/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/InvalidDataTest.cs
@@ -162,7 +162,7 @@ namespace CommonConcepts.Test
                     var error = TestUtility.ShouldFail<Rhetos.UserException>(
                         () => simple2.Insert(newItem),
                         test.Item2);
-                    Console.WriteLine("ErrorMessage: " + ExceptionsUtility.SafeFormatUserMessage(error));
+                    Console.WriteLine("ErrorMessage: " + ExceptionsUtility.MessageForLog(error));
                     Console.WriteLine("Exception: " + error.ToString());
                 }
             }

--- a/Source/MsBuildIntegration/Rhetos.targets
+++ b/Source/MsBuildIntegration/Rhetos.targets
@@ -9,7 +9,7 @@
     <Target Name="BuildRhetosApp" DependsOnTargets="ResolveRhetosProjectAssets;" BeforeTargets="CoreCompile" Condition="'$(RhetosBuild)'=='True' and $(BuildingProject)=='True'" Inputs="@(RhetosInput);@(RhetosBuild)" Outputs="@(RhetosOutput)">
 		<Message Text="BuildRhetosApp" />
         <Delete Files="$(RhetosBuildCompleteFile)" />
-        <Exec Command="&quot;$(RhetosCliExecutablePath)&quot; build &quot;$(ProjectDir).&quot;" CustomErrorRegularExpression="\[Error\]" CustomWarningRegularExpression="\[Warn\]" />
+        <Exec Command="&quot;$(RhetosCliExecutablePath)&quot; build --msbuild-format &quot;$(ProjectDir).&quot;" CustomErrorRegularExpression="\[Error\]" CustomWarningRegularExpression="\[Warn\]" />
         <WriteLinesToFile File="$(RhetosBuildCompleteFile)" Lines="" Overwrite="true" />
     </Target>
 

--- a/Source/Rhetos.Configuration.Autofac/ApplicationDeployment.cs
+++ b/Source/Rhetos.Configuration.Autofac/ApplicationDeployment.cs
@@ -21,6 +21,7 @@ using Autofac;
 using Autofac.Core;
 using Rhetos.Configuration.Autofac.Modules;
 using Rhetos.Deployment;
+using Rhetos.Dsl;
 using Rhetos.Extensibility;
 using Rhetos.Logging;
 using Rhetos.Security;
@@ -30,6 +31,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace Rhetos
 {
@@ -170,10 +172,21 @@ namespace Rhetos
 
             Console.WriteLine();
             Console.WriteLine("=============== ERROR SUMMARY ===============");
-            Console.WriteLine(ex.GetType().Name + ": " + ExceptionsUtility.SafeFormatUserMessage(ex));
+            Console.WriteLine(ex.GetType().Name + ": " + ExceptionsUtility.MessageForLog(ex));
             Console.WriteLine("=============================================");
             Console.WriteLine();
             Console.WriteLine("See DeployPackages.log for more information on error. Enable TraceLog in DeployPackages.exe.config for even more details.");
+        }
+
+        public static void PrintCanonicalError(DslSyntaxException dslException)
+        {
+            string origin = dslException.FilePosition?.CanonicalOrigin ?? "Rhetos DSL";
+            string canonicalError = $"{origin}: error {dslException.ErrorCode ?? "RH0000"}: {dslException.Message.Replace('\r', ' ').Replace('\n', ' ')}";
+
+            var oldColor = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine(canonicalError);
+            Console.ForegroundColor = oldColor;
         }
 
         public void RestartWebServer()

--- a/Source/Rhetos.Dsl.Interfaces/DslParseSyntaxException.cs
+++ b/Source/Rhetos.Dsl.Interfaces/DslParseSyntaxException.cs
@@ -25,18 +25,21 @@ using System.Threading.Tasks;
 
 namespace Rhetos.Dsl
 {
+    [Obsolete("Use DslSyntaxException instead.")]
     public class DslParseSyntaxException : DslSyntaxException
     {
         public readonly string SimpleMessage;
-        public readonly DslScript DslScript;
-        public readonly int Position;
 
         public DslParseSyntaxException(string formattedMessage, string simpleMessage, DslScript dslScript, int position)
-            : base(formattedMessage)
+            : base(formattedMessage, null, dslScript, position, 0, null)
         {
             this.SimpleMessage = simpleMessage;
-            this.DslScript = dslScript;
-            this.Position = position;
+        }
+
+        public DslParseSyntaxException(string message, string errorCode, DslScript dslScript, int positionBegin, int positionEnd, string details)
+            : base(message, errorCode, dslScript, positionBegin, positionEnd, details)
+        {
+            this.SimpleMessage = message;
         }
     }
 }

--- a/Source/Rhetos.Dsl.Interfaces/DslParseSyntaxException.cs
+++ b/Source/Rhetos.Dsl.Interfaces/DslParseSyntaxException.cs
@@ -18,10 +18,6 @@
 */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Rhetos.Dsl
 {
@@ -29,12 +25,6 @@ namespace Rhetos.Dsl
     public class DslParseSyntaxException : DslSyntaxException
     {
         public readonly string SimpleMessage;
-
-        public DslParseSyntaxException(string formattedMessage, string simpleMessage, DslScript dslScript, int position)
-            : base(formattedMessage, null, dslScript, position, 0, null)
-        {
-            this.SimpleMessage = simpleMessage;
-        }
 
         public DslParseSyntaxException(string message, string errorCode, DslScript dslScript, int positionBegin, int positionEnd, string details)
             : base(message, errorCode, dslScript, positionBegin, positionEnd, details)

--- a/Source/Rhetos.Dsl.Interfaces/DslSyntaxException.cs
+++ b/Source/Rhetos.Dsl.Interfaces/DslSyntaxException.cs
@@ -19,6 +19,7 @@
 
 using Rhetos.Utilities;
 using System;
+using System.Collections.Generic;
 using System.Text;
 
 namespace Rhetos.Dsl
@@ -48,17 +49,22 @@ namespace Rhetos.Dsl
           System.Runtime.Serialization.StreamingContext context)
             : base(info, context) { }
 
-        public DslSyntaxException(string message, string errorCode, DslScript dslScript, int positionBegin = 0, int positionEnd = 0, string details = null)
+        public DslSyntaxException(string message, string errorCode, DslScript dslScript, int positionBegin = 0, int positionEnd = 0, string additionalDetails = null)
             : base(message)
         {
             ErrorCode = errorCode;
             DslScript = dslScript;
             Position = positionBegin;
 
-            if (!string.IsNullOrEmpty(dslScript.Path))
+            if (!string.IsNullOrEmpty(dslScript?.Path))
                 FilePosition = new FilePosition(dslScript.Path, dslScript.Script, positionBegin, positionEnd);
 
-            Details = details;
+            var detailsList = new List<string>();
+            if (!string.IsNullOrEmpty(dslScript?.Script))
+                detailsList.Add($"Syntax error at \"{ScriptPositionReporting.ReportPreviousAndFollowingTextInline(dslScript.Script, positionBegin)}\"");
+            if (!string.IsNullOrEmpty(additionalDetails))
+                detailsList.Add(additionalDetails);
+            Details = string.Join("\r\n", detailsList);
         }
 
         public override string ToString() => ReportWithFilePositionAndDetails(base.ToString());

--- a/Source/Rhetos.Dsl.Interfaces/DslSyntaxException.cs
+++ b/Source/Rhetos.Dsl.Interfaces/DslSyntaxException.cs
@@ -17,18 +17,25 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using Rhetos.Utilities;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Globalization;
-using System.Diagnostics.Contracts;
 
 namespace Rhetos.Dsl
 {
-    [global::System.Serializable]
-    public class DslSyntaxException : FrameworkException
+    [Serializable]
+    public class DslSyntaxException : RhetosException
     {
+        [Obsolete("Use FilePosition instead.")]
+        public readonly DslScript DslScript;
+
+        [Obsolete("Use FilePosition instead.")]
+        public readonly int Position;
+
+        public readonly string ErrorCode;
+        public readonly FilePosition FilePosition;
+        public readonly string Details;
+
         public DslSyntaxException() { }
         public DslSyntaxException(string message) : base(message) { }
         public DslSyntaxException(string message, Exception inner) : base(message, inner) { }
@@ -40,5 +47,36 @@ namespace Rhetos.Dsl
           System.Runtime.Serialization.SerializationInfo info,
           System.Runtime.Serialization.StreamingContext context)
             : base(info, context) { }
+
+        public DslSyntaxException(string message, string errorCode, DslScript dslScript, int positionBegin = 0, int positionEnd = 0, string details = null)
+            : base(message)
+        {
+            ErrorCode = errorCode;
+            DslScript = dslScript;
+            Position = positionBegin;
+
+            if (!string.IsNullOrEmpty(dslScript.Path))
+                FilePosition = new FilePosition(dslScript.Path, dslScript.Script, positionBegin, positionEnd);
+
+            Details = details;
+        }
+
+        public override string ToString() => ReportWithFilePositionAndDetails(base.ToString());
+
+        public override string MessageForLog() => ReportWithFilePositionAndDetails(Message);
+
+        private string ReportWithFilePositionAndDetails(string message)
+        {
+            var report = new StringBuilder();
+            report.Append(message);
+
+            if (!string.IsNullOrEmpty(FilePosition?.Path))
+                report.AppendLine().Append(FilePosition.CanonicalOrigin);
+
+            if (!string.IsNullOrEmpty(Details))
+                report.AppendLine().AppendLine("Details:").Append(CsUtility.Indent(Details, 3));
+
+            return report.ToString();
+        }
     }
 }

--- a/Source/Rhetos.Dsl/DslParser.cs
+++ b/Source/Rhetos.Dsl/DslParser.cs
@@ -221,28 +221,24 @@ namespace Rhetos.Dsl
                     var errorsReport = string.Join("\r\n", errorReportValues.Select(x => x.formattedError)).Limit(500, "...");
                     var simpleErrorsReport = string.Join("\n", errorReportValues.Select(x => x.simpleError));
                     var simpleMessage = $"Invalid parameters after keyword '{keyword}'. Possible causes: {simpleErrorsReport}";
-                    var formattedMessage = $"{simpleMessage} {tokenReader.ReportPosition()}\r\n\r\nPossible causes:\r\n{errorsReport}";
-                    throw new DslParseSyntaxException(formattedMessage, simpleMessage, dslScript, position);
+                    var possibleCauses = $"Possible causes:\r\n{errorsReport}";
+                    throw new DslParseSyntaxException(simpleMessage, "RH0003", dslScript, position, 0, possibleCauses);
                 }
                 else if (!string.IsNullOrEmpty(keyword))
                 {
                     var simpleMessage = $"Unrecognized concept keyword '{keyword}'.";
-                    throw new DslParseSyntaxException($"{simpleMessage} {tokenReader.ReportPosition()}", simpleMessage, dslScript, position);
+                    throw new DslParseSyntaxException(simpleMessage, "RH0004", dslScript, position, 0, null);
                 }
                 else
                 {
                     var simpleMessage = $"Invalid DSL script syntax.";
-                    throw new DslParseSyntaxException($"{simpleMessage} {tokenReader.ReportPosition()}", simpleMessage, dslScript, position);
+                    throw new DslParseSyntaxException(simpleMessage, "RH0005", dslScript, position, 0, null);
             }
             }
 
             Disambiguate(possibleInterpretations);
             if (possibleInterpretations.Count > 1)
             {
-                var report = new List<string>();
-                report.Add($"Ambiguous syntax. {tokenReader.ReportPosition()}");
-                report.Add($"There are multiple possible interpretations of keyword '{keyword}':");
-
                 var interpretations = new List<string>();
                 for (int i = 0; i < possibleInterpretations.Count; i++)
                     interpretations.Add($"{i + 1}. {possibleInterpretations[i].ConceptInfo.GetType().AssemblyQualifiedName}");
@@ -250,7 +246,7 @@ namespace Rhetos.Dsl
                 var simpleMessage = $"Ambiguous syntax. There are multiple possible interpretations of keyword '{keyword}': {string.Join(", ", interpretations)}.";
                 var (dslScript, position) = tokenReader.GetPositionInScript();
 
-                throw new DslParseSyntaxException(string.Join("\r\n", report.Concat(interpretations)), simpleMessage, dslScript, position);
+                throw new DslParseSyntaxException(simpleMessage, "RH0006", dslScript, position, 0, null);
             }
 
             var parsedStatement = possibleInterpretations.Single();
@@ -349,7 +345,7 @@ namespace Rhetos.Dsl
                 {
                     var simpleMessage = "Unexpected \"}\".";
                     var (dslScript, position) = tokenReader.GetPositionInScript();
-                    throw new DslParseSyntaxException($"{tokenReader.ReportPosition()}\r\n{simpleMessage} ", simpleMessage, dslScript, position);
+                    throw new DslParseSyntaxException(simpleMessage, "RH0007", dslScript, position, 0, null);
 
                 }
                 context.Pop();

--- a/Source/Rhetos.Dsl/DslParser.cs
+++ b/Source/Rhetos.Dsl/DslParser.cs
@@ -163,7 +163,7 @@ namespace Rhetos.Dsl
             {
                 var (dslScript, position) = tokenReader.GetPositionInScript();
                 throw new DslParseSyntaxException($"Expected \"}}\" to close concept \"{context.Peek()}\".",
-                    "RH0002", dslScript, position, 0, ReportErrorContext(context.Peek(), tokenReader));
+                    "RH0002", dslScript, position, 0, ReportPreviousConcept(context.Peek()));
             }
 
             foreach (string warning in warnings)
@@ -311,13 +311,9 @@ namespace Rhetos.Dsl
             return options;
         }
 
-        private string ReportErrorContext(IConceptInfo conceptInfo, TokenReader tokenReader)
+        private string ReportPreviousConcept(IConceptInfo conceptInfo)
         {
             var sb = new StringBuilder();
-
-            var (dslScript, position) = tokenReader.GetPositionInScript();
-            if (!string.IsNullOrEmpty(dslScript.Script))
-                sb.AppendLine($"Syntax error at \"{ScriptPositionReporting.ReportPreviousAndFollowingTextInline(dslScript.Script, position)}\"");
 
             if (conceptInfo != null)
             {
@@ -344,7 +340,7 @@ namespace Rhetos.Dsl
             {
                 var (dslScript, position) = tokenReader.GetPositionInScript();
                 throw new DslParseSyntaxException("Expected \";\" or \"{\".",
-                    "RH0001", dslScript, position, 0, ReportErrorContext(conceptInfo, tokenReader));
+                    "RH0001", dslScript, position, 0, ReportPreviousConcept(conceptInfo));
             }
 
             while (tokenReader.TryRead("}"))

--- a/Source/Rhetos.Dsl/TokenReader.cs
+++ b/Source/Rhetos.Dsl/TokenReader.cs
@@ -66,14 +66,6 @@ namespace Rhetos.Dsl
 
         public bool EndOfInput { get { return PositionInTokenList >= _tokenList.Count; } }
 
-        private static void ThrowReadException(string value, string reason)
-        {
-            throw new DslSyntaxException(string.Format(CultureInfo.InvariantCulture,
-                "{0}Expected \"{1}\". ",
-                    string.IsNullOrEmpty(reason) ? "" : (reason + " "),
-                    value));
-        }
-
         public bool TryRead(string value)
         {
             if (PositionInTokenList >= _tokenList.Count || CurrentToken.Type == TokenType.EndOfFile)

--- a/Source/Rhetos.Dsl/Tokenizer.cs
+++ b/Source/Rhetos.Dsl/Tokenizer.cs
@@ -31,7 +31,7 @@ namespace Rhetos.Dsl
         private readonly IDslScriptsProvider _dslScriptsProvider;
         private readonly FilesUtility _filesUtility;
         List<Token> _tokens = null;
-        object _tokensLock = new object();
+        readonly object _tokensLock = new object();
 
         public Tokenizer(IDslScriptsProvider dslScriptsProvider, FilesUtility filesUtility)
         {
@@ -202,7 +202,7 @@ namespace Rhetos.Dsl
             return c == '<';
         }
 
-        private static HashSet<char> invalidPathChars = new HashSet<char>(Path.GetInvalidPathChars());
+        private static readonly HashSet<char> invalidPathChars = new HashSet<char>(Path.GetInvalidPathChars());
 
         private static string ReadExternalText(DslScript dslScript, ref int end, Func<string, string> readAllTextfromFile)
         {

--- a/Source/Rhetos.Dsl/Tokenizer.cs
+++ b/Source/Rhetos.Dsl/Tokenizer.cs
@@ -17,12 +17,11 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using Rhetos.Utilities;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.IO;
-using Rhetos.Utilities;
+using System.Linq;
 
 namespace Rhetos.Dsl
 {
@@ -178,7 +177,7 @@ namespace Rhetos.Dsl
                 if (end >= script.Length)
                 {
                     var errorMessage = $"Unexpected end of script within quoted string. Missing closing character: {quote}.";
-                    throw new DslParseSyntaxException($"{errorMessage} {dslScript.ReportPosition(begin)}", errorMessage, dslScript, begin);
+                    throw new DslParseSyntaxException(errorMessage, "RH0008", dslScript, begin, 0, null);
                 }
                 if (end + 1 < script.Length && script[end + 1] == quote)
                 {
@@ -216,13 +215,13 @@ namespace Rhetos.Dsl
             if (end >= script.Length)
             {
                 var errorMessage = "Unexpected end of script within external text reference. Missing closing character: '>'.";
-                throw new DslParseSyntaxException($"{errorMessage} {dslScript.ReportPosition(end)}", errorMessage, dslScript, end);
+                throw new DslParseSyntaxException(errorMessage, "RH0009", dslScript, begin, 0, null);
             }
 
             if (script[end] != '>')
             {
                 var errorMessage = "Invalid filename character within external text reference.";
-                throw new DslParseSyntaxException($"{errorMessage} {dslScript.ReportPosition(end)}", errorMessage, dslScript, end);
+                throw new DslParseSyntaxException(errorMessage, "RH0010", dslScript, end, 0, null);
             }
 
             end++; // Skip closing character.
@@ -244,7 +243,7 @@ namespace Rhetos.Dsl
                 if (string.IsNullOrWhiteSpace(fileName))
                 {
                     var errorMessage = $"Referenced empty file name ({basicFilePath}) in DSL script.";
-                    throw new DslParseSyntaxException($"{errorMessage} {dslScript.ReportPosition(begin)}", errorMessage, dslScript, begin);
+                    throw new DslParseSyntaxException(errorMessage, "RH0011", dslScript, begin, 0, null);
                 }
 
                 // Look for SQL dialect-specific files before the generic SQL file:
@@ -258,7 +257,7 @@ namespace Rhetos.Dsl
 
             var notFoundMessage = "Cannot find the extension file referenced in DSL script.";
             var fileListMessage = "Looking for files:\r\n" + string.Join("\r\n", filePaths);
-            throw new DslParseSyntaxException($"{notFoundMessage} {dslScript.ReportPosition(begin)}\r\n{fileListMessage}", $"{notFoundMessage} {fileListMessage}", dslScript, begin);
+            throw new DslParseSyntaxException($"{notFoundMessage} {fileListMessage}", "RH0012", dslScript, begin, 0, null);
         }
     }
 }

--- a/Source/Rhetos.TestCommon/TestUtility.cs
+++ b/Source/Rhetos.TestCommon/TestUtility.cs
@@ -51,7 +51,7 @@ namespace Rhetos.TestCommon
 
             Assert.IsNotNull(exception, "Expected exception did not happen.");
 
-            string message = exception.GetType().Name + ": " + ExceptionsUtility.SafeFormatUserMessage(exception);
+            string message = exception.GetType().Name + ": " + ExceptionsUtility.MessageForLog(exception);
             if (exception is UserException && ((UserException)exception).SystemMessage != null)
                 message += "\r\n  SystemMessage: " + ((UserException)exception).SystemMessage;
             Console.WriteLine("[ShouldFail] " + message);

--- a/Source/Rhetos.Utilities.Test/CsUtilityTest.cs
+++ b/Source/Rhetos.Utilities.Test/CsUtilityTest.cs
@@ -304,5 +304,15 @@ Dictionary`2<List`1<InnerClass[]>, InnerClass>";
         }
 
         class InnerClass { };
+
+        [TestMethod]
+        public void Indent()
+        {
+            Assert.AreEqual("", CsUtility.Indent("", 0));
+            Assert.AreEqual(" a", CsUtility.Indent("a", 1));
+            Assert.AreEqual("  a", CsUtility.Indent("a", 2));
+            Assert.AreEqual("  a\r\n  b", CsUtility.Indent("a\r\nb", 2));
+            Assert.AreEqual("  a\r\n  b", CsUtility.Indent("a\nb", 2));
+        }
     }
 }

--- a/Source/Rhetos.Utilities.Test/UserExceptionTest.cs
+++ b/Source/Rhetos.Utilities.Test/UserExceptionTest.cs
@@ -46,7 +46,7 @@ namespace Rhetos.Utilities.Test
             foreach (var test in tests)
             {
                 Console.WriteLine("Test: " + test.Item1.ToString());
-                string result = ExceptionsUtility.SafeFormatUserMessage(test.Item1);
+                string result = ExceptionsUtility.MessageForLog(test.Item1);
                 Assert.AreEqual(test.Item2, result);
             }
         }

--- a/Source/Rhetos.Utilities/CsUtility.cs
+++ b/Source/Rhetos.Utilities/CsUtility.cs
@@ -76,6 +76,11 @@ namespace Rhetos.Utilities
             return value;
         }
 
+        public static string Indent(string lines, int indentation)
+        {
+            return string.Join("\r\n", lines.Replace("\r\n", "\n").Replace("\r", "\n").Split('\n').Select(line => new string(' ', indentation) + line));
+        }
+
         /// <summary>
         /// Reads a value from the dictionary, with extended error handling.
         /// Parameter exceptionMessage can contain format tag {0} that will be replaced by missing key.

--- a/Source/Rhetos.Utilities/Exceptions/RhetosException.cs
+++ b/Source/Rhetos.Utilities/Exceptions/RhetosException.cs
@@ -46,8 +46,18 @@ namespace Rhetos
 
         public override string ToString()
         {
-            return base.ToString()
-                + "\r\nInfo: " + (Info != null ? string.Join(", ", Info.Select(info => info.Key.ToString() + "=" + info.Value.ToString())) : "null");
+            string infoReport;
+            if (Info?.Any() == true)
+                infoReport = "\r\nInfo: " + string.Join(", ", Info.Select(info => $"{info.Key}={info.Value}"));
+            else
+                infoReport = "";
+
+            return base.ToString() + infoReport;
+        }
+
+        public virtual string MessageForLog()
+        {
+            return Message;
         }
     }
 }

--- a/Source/Rhetos.Utilities/Exceptions/UserException.cs
+++ b/Source/Rhetos.Utilities/Exceptions/UserException.cs
@@ -26,7 +26,7 @@ namespace Rhetos
     /// These errors result from end user's incorrect usage of the application.
     /// Web response HTTP status code on this exception is 400.
     /// </summary>
-    [global::System.Serializable]
+    [Serializable]
     public class UserException : RhetosException
     {
         public string SystemMessage; // TODO: Remove this property and switch to RhetosException.Info property for error metadata.
@@ -68,6 +68,33 @@ namespace Rhetos
             return base.ToString()
                 + "\r\nMessageParameters: " + (MessageParameters != null ? string.Join(", ", MessageParameters) : "null")
                 + "\r\nSystemMessage: " + SystemMessage;
+        }
+
+        /// <summary>
+        /// Evaluates the message parameters with string.Format, without localization.
+        /// Use this method in error logging to make sure every error is logged even if it's message format is not valid.
+        /// </summary>
+        public override string MessageForLog()
+        {
+            try
+            {
+                return string.Format(Message, MessageParameters ?? new object[] { });
+            }
+            catch (Exception e)
+            {
+
+                string parametersReport;
+                if (MessageParameters == null)
+                    parametersReport = "null";
+                else if (MessageParameters.Length == 0)
+                    parametersReport = "no parameters";
+                else
+                    parametersReport = "\"" + string.Join(", ", MessageParameters) + "\"";
+
+                return $"Invalid error message format. Message: \"{Message ?? "null"}\"," +
+                    $" Parameters: {parametersReport}," +
+                    $" {e.GetType().Name}: {e.Message}";
+            }
         }
     }
 }

--- a/Source/Rhetos.Utilities/ExceptionsUtility.cs
+++ b/Source/Rhetos.Utilities/ExceptionsUtility.cs
@@ -59,30 +59,15 @@ namespace Rhetos.Utilities
         }
 
         /// <summary>
-        /// It the exception is a UserException, this function evaluates the message parameters using string.Format, without localization.
-        /// Use this method in error logging to make sure every error is logger even if it's message format is not valid.
+        /// If the exception is a UserException, this function evaluates the message parameters using string.Format, without localization.
+        /// Use this method in error logging to make sure every error is logged even if it's message format is not valid.
         /// </summary>
-        public static string SafeFormatUserMessage(Exception ex)
+        public static string MessageForLog(Exception ex)
         {
-            var userEx = ex as UserException;
-            if (userEx == null)
+            if (ex is RhetosException rhetosException)
+                return rhetosException.MessageForLog();
+            else
                 return ex.Message;
-            try
-            {
-                return string.Format(userEx.Message, userEx.MessageParameters ?? new object[] { });
-            }
-            catch (Exception ex2)
-            {
-                return "Invalid error message format. Message: " + (ex.Message == null
-                        ? "null"
-                        : "\"" + ex.Message + "\"")
-                    + ", Parameters: " + (userEx.MessageParameters == null
-                        ? "null"
-                        : userEx.MessageParameters.Length == 0
-                            ? "no parameters"
-                            : "\"" + string.Join(", ", userEx.MessageParameters) + "\"")
-                    + ", " + ex2.GetType().Name + ": " + ex2.Message;
-            }
         }
     }
 }

--- a/Source/Rhetos.Utilities/FilePosition.cs
+++ b/Source/Rhetos.Utilities/FilePosition.cs
@@ -1,0 +1,79 @@
+﻿/*
+    Copyright (C) 2014 Omega software d.o.o.
+
+    This file is part of Rhetos.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using Rhetos.Utilities;
+
+namespace Rhetos.Dsl
+{
+    /// <summary>
+    /// Position in file for reporting location of an error.
+    /// File path is required, but the file does not need to exit on disk.
+    /// Position is optional. It can represent one location (begin only) or a range (begin and end).
+    /// </summary>
+    public class FilePosition
+    {
+        public string Path { get; }
+        public int BeginLine { get; }
+        public int BeginColumn { get; }
+        public int EndLine { get; }
+        public int EndColumn { get; }
+
+        public FilePosition(string filePath, string fileContent = "", int positionBegin = 0, int positionEnd = 0)
+        {
+            Path = filePath;
+
+            if (!string.IsNullOrEmpty(filePath) && !string.IsNullOrEmpty(fileContent))
+            {
+                (BeginLine, BeginColumn) = ScriptPositionReporting.GetLineColumn(fileContent, positionBegin);
+                (EndLine, EndColumn) = ScriptPositionReporting.GetLineColumn(fileContent, positionEnd);
+            }
+        }
+
+        public string CanonicalOrigin
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(Path))
+                {
+                    string location;
+
+                    if (BeginLine > 0)
+                    {
+                        if (BeginColumn > 0)
+                        {
+                            if (EndLine > BeginLine || EndLine == BeginLine && EndColumn > BeginColumn)
+                                location = $"({BeginLine},{BeginColumn},{EndLine},{EndColumn})";
+                            else
+                                location = $"({BeginLine},{BeginColumn})";
+                        }
+                        else
+                            location = $"({BeginLine})";
+                    }
+                    else
+                        location = "";
+
+                    return Path + location;
+
+                }
+                else
+                    return null;
+            }
+        }
+    }
+}

--- a/Source/Rhetos.Utilities/Rhetos.Utilities.csproj
+++ b/Source/Rhetos.Utilities/Rhetos.Utilities.csproj
@@ -152,6 +152,7 @@
     <Compile Include="ApplicationConfiguration\ConfigurationSources\KeyValuesSource.cs" />
     <Compile Include="ApplicationConfiguration\RhetosAppEnvironmentProvider.cs" />
     <Compile Include="BuildOptions.cs" />
+    <Compile Include="FilePosition.cs" />
     <Compile Include="Legacy\LegacyUtilities.cs" />
     <Compile Include="Legacy\Configuration.cs" />
     <Compile Include="Legacy\ConfigUtility.cs" />

--- a/Source/Rhetos.Utilities/ScriptPositionReporting.cs
+++ b/Source/Rhetos.Utilities/ScriptPositionReporting.cs
@@ -83,11 +83,17 @@ namespace Rhetos.Utilities
             return text;
         }
 
-        public static string ReportPosition(string text, int position, string filePath = null)
+        public static (int Line, int Column) GetLineColumn(string text, int position)
         {
             position = PositionWithinRange(text, position);
+            return (Line(text, position), Column(text, position));
+        }
+
+        public static string ReportPosition(string text, int position, string filePath = null)
+        {
+            var location = GetLineColumn(text, position);
             string fileInfo = filePath != null ? " file '" + filePath + "'," : "";
-            string fileAndPositionInfo = $"At line {Line(text, position)}, column {Column(text, position)},{fileInfo}\r\n";
+            string fileAndPositionInfo = $"At line {location.Line}, column {location.Column},{fileInfo}\r\n";
             return $"{fileAndPositionInfo}{ReportPreviousAndFollowingText(text, position)}";
         }
 
@@ -96,6 +102,13 @@ namespace Rhetos.Utilities
             position = PositionWithinRange(text, position);
             return $" after: \"{PreviousText(text, position, 70)}\",\r\n before: \"{FollowingText(text, position, 70)}\".";
         }
+
+        public static string ReportPreviousAndFollowingTextInline(string text, int position)
+        {
+            position = PositionWithinRange(text, position);
+            return $"{PreviousText(text, position, 70)} >>>{FollowingText(text, position, 70)}";
+        }
+
         private static int PositionWithinRange(string text, int position)
         {
             if (position > text.Length)

--- a/Source/RhetosCli/RhetosCli.csproj
+++ b/Source/RhetosCli/RhetosCli.csproj
@@ -69,6 +69,10 @@
       <Project>{945537dc-4af7-4def-b73c-07f19229efe6}</Project>
       <Name>Rhetos.Deployment.Interfaces</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Rhetos.Dsl.Interfaces\Rhetos.Dsl.Interfaces.csproj">
+      <Project>{F4ACD412-2782-4191-8708-C7AE99B0CEE9}</Project>
+      <Name>Rhetos.Dsl.Interfaces</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Rhetos.Logging\Rhetos.Logging.csproj">
       <Project>{8c9f1c24-2d9c-420b-9787-3fcad96c5b3e}</Project>
       <Name>Rhetos.Logging</Name>


### PR DESCRIPTION
Formatting DSL error in canonical format for better integration with MSBuild (file and position).
New rhetos build switch --msbuild-format will suppress standard DSL syntax error output and only report the canonical error.