### PR TITLE
Added dbupdate configuration file "rhetos-dbupdate.settings.json", to…

### DIFF
--- a/Source/DeployPackages/Program.cs
+++ b/Source/DeployPackages/Program.cs
@@ -108,9 +108,10 @@ namespace DeployPackages
             if (deployOptions.StartPaused)
                 StartPaused();
 
-            var build = new ApplicationBuild(configurationProvider, logProvider, () => GetBuildPlugins(Path.Combine(rhetosAppRootPath, "bin", "Plugins")));
             if (!deployOptions.DatabaseOnly)
             {
+                var build = new ApplicationBuild(configurationProvider, logProvider, () => GetBuildPlugins(Path.Combine(rhetosAppRootPath, "bin", "Plugins")));
+                LegacyUtilities.Initialize(configurationProvider);
                 DeleteObsoleteFiles(logProvider, logger);
                 var installedPackages = build.DownloadPackages(deployOptions.IgnoreDependencies);
                 build.GenerateApplication(installedPackages);
@@ -206,7 +207,6 @@ namespace DeployPackages
                 });
 
             var deployment = new ApplicationDeployment(configurationProvider, logProvider, LegacyUtilities.GetRuntimeAssembliesDelegate(configurationProvider));
-
             deployment.UpdateDatabase();
             deployment.InitializeGeneratedApplication(host.RhetosRuntime);
             deployment.RestartWebServer();

--- a/Source/Rhetos.Configuration.Autofac/ApplicationBuild.cs
+++ b/Source/Rhetos.Configuration.Autofac/ApplicationBuild.cs
@@ -43,7 +43,6 @@ namespace Rhetos
             _configurationProvider = configurationProvider;
             _logProvider = logProvider;
             _pluginAssemblies = pluginAssemblies;
-            LegacyUtilities.Initialize(configurationProvider);
         }
 
         public InstalledPackages DownloadPackages(bool ignoreDependencies)

--- a/Source/Rhetos.Configuration.Autofac/ApplicationDeployment.cs
+++ b/Source/Rhetos.Configuration.Autofac/ApplicationDeployment.cs
@@ -46,7 +46,6 @@ namespace Rhetos
             _configurationProvider = configurationProvider;
             _logProvider = logProvider;
             _pluginAssemblies = pluginAssemblies;
-            LegacyUtilities.Initialize(configurationProvider);
         }
 
         //=====================================================================

--- a/Source/Rhetos.Utilities/DbUpdateOptions.cs
+++ b/Source/Rhetos.Utilities/DbUpdateOptions.cs
@@ -21,6 +21,8 @@ namespace Rhetos.Utilities
 {
     public class DbUpdateOptions
     {
+        public static readonly string ConfigurationFileName = "rhetos-dbupdate.settings.json";
+
         public bool ShortTransactions { get; set; } = false;
         public bool DataMigration__SkipScriptsWithWrongOrder { get; set; } = false;
         public bool SkipRecompute { get; set; } = false;

--- a/Source/RhetosCli/Program.cs
+++ b/Source/RhetosCli/Program.cs
@@ -137,6 +137,7 @@ namespace Rhetos
             var configurationProvider = host.RhetosRuntime.BuildConfiguration(LogProvider, host.ConfigurationFolder, configurationBuilder =>
             {
                 configurationBuilder.AddKeyValue(nameof(DatabaseOptions.SqlCommandTimeout), 0);
+                configurationBuilder.AddJsonFile(Path.Combine(host.ConfigurationFolder, DbUpdateOptions.ConfigurationFileName), optional: true);
                 if (shortTransactions)
                     configurationBuilder.AddKeyValue(nameof(DbUpdateOptions.ShortTransactions), shortTransactions);
                 if (skipRecompute)


### PR DESCRIPTION
… allow overriding settings specific to 'rhetos dbupdate', such as SqlCommandTimeout.

Configuration settings order for dbupdate is now the following (each can override previous ones):
1. runtime configuration "rhetos-dbupdate.settings.json"
2. turned of SQL command timeout (default behavior for dbupdate)
3. dbupdate configuration "rhetos-dbupdate.settings.json"
4. rhetos CLI switches