### PR TITLE
Rhetos CLI warning for NuGet packages with DLLs in "Plugins" subfolder

### DIFF
--- a/Source/Rhetos.Utilities/Legacy/LegacyPathsOptions.cs
+++ b/Source/Rhetos.Utilities/Legacy/LegacyPathsOptions.cs
@@ -27,7 +27,7 @@ namespace Rhetos.Utilities
     public class LegacyPathsOptions
     {
         /// <summary>
-        /// At build-time, returns target bin folder. At run-time returns host assembly folder.
+        /// At build-time, returns target bin folder with Rhetos framework libraries. At run-time returns host assembly folder.
         /// </summary>
         [OptionsPath]
         public string BinFolder { get; set; }

--- a/Source/RhetosCli/Program.cs
+++ b/Source/RhetosCli/Program.cs
@@ -127,6 +127,7 @@ namespace Rhetos
             AppDomain.CurrentDomain.AssemblyResolve += GetSearchForAssemblyDelegate(rhetosProjectContent.RhetosProjectAssets.Assemblies.ToArray());
 
             var build = new ApplicationBuild(configurationProvider, LogProvider, () => rhetosProjectContent.RhetosProjectAssets.Assemblies);
+            build.ReportLegacyPluginsFolders(rhetosProjectContent.RhetosProjectAssets.InstalledPackages);
             build.GenerateApplication(rhetosProjectContent.RhetosProjectAssets.InstalledPackages);
         }
 

--- a/Source/RhetosCli/Program.cs
+++ b/Source/RhetosCli/Program.cs
@@ -116,8 +116,8 @@ namespace Rhetos
                 .AddOptions(rhetosProjectContent.RhetosTargetEnvironment)
                 .AddOptions(new LegacyPathsOptions
                 {
-                    BinFolder = null, // It should not be needed for build with Rhetos CLI.
-                    PluginsFolder = null, // It should not be needed for build with Rhetos CLI.
+                    BinFolder = null, // // Rhetos CLI does not use bin folder at build-time. Rhetos framework libraries are provided by NuGet.
+                    PluginsFolder = null, // Rhetos CLI does not manage plugin libraries directly, they are provided by NuGet.
                     ResourcesFolder = Path.Combine(projectRootPath, "Resources"), // Currently supporting old plugins by default.
                 })
                 .AddConfigurationManagerConfiguration()


### PR DESCRIPTION
Rhetos CLI does not support legacy Rhetos NuGet packages with DLLs in "Plugins" subfolder.

The support could be implemented, but it is in conflict with new approach where Rhetos CLI should not handle standard features of Visual Studio, MSBuild and NuGet.