### PR TITLE
PluginsScanner cache for runtime was not reused between build on MSBuild integration

### DIFF
--- a/Source/DeployPackages/App.config
+++ b/Source/DeployPackages/App.config
@@ -44,7 +44,7 @@
       <logger name="*" minLevel="Info" writeTo="ConsoleLog"/>
       <logger name="*" minLevel="Info" writeTo="MainLog"/>
       <logger name="DatabaseGeneratorChanges" level="Trace" writeTo="MainLog"/>
-      <logger name="Performance" minLevel="Trace" writeTo="PerformanceLog"/>
+      <logger name="Performance*" minLevel="Trace" writeTo="PerformanceLog"/>
       <!-- <logger name="*" minLevel="Trace" writeTo="TraceLog"/> -->
     </rules>
   </nlog>

--- a/Source/MsBuildIntegration/Rhetos.MSBuild.targets
+++ b/Source/MsBuildIntegration/Rhetos.MSBuild.targets
@@ -70,7 +70,8 @@
         </PropertyGroup>
         <Copy SourceFiles="$(_PluginScannerCachePath)" Retries="$(CopyRetryCount)" RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
             DestinationFiles="$(TargetDir)\PluginScanner.json" 
-            SkipUnchangedFiles="True">
+            SkipUnchangedFiles="True"
+            Condition="!Exists('$(TargetDir)\PluginScanner.json')">
             <Output TaskParameter="CopiedFiles" ItemName="_CopiedPluginScannerCache" />
         </Copy>
         <ItemGroup>

--- a/Source/MsBuildIntegration/Rhetos.MSBuild.targets
+++ b/Source/MsBuildIntegration/Rhetos.MSBuild.targets
@@ -72,11 +72,7 @@
             DestinationFiles="$(TargetDir)\PluginScanner.json" 
             SkipUnchangedFiles="True"
             Condition="!Exists('$(TargetDir)\PluginScanner.json')">
-            <Output TaskParameter="CopiedFiles" ItemName="_CopiedPluginScannerCache" />
         </Copy>
-        <ItemGroup>
-            <FileWrites Include="@(_CopiedPluginScannerCache)" />
-        </ItemGroup>
     </Target>
 
     <Target Name="DeployRhetosApp" DependsOnTargets="BuildRhetosApp;CopyFilesToOutputDirectory" AfterTargets="Build" Condition="'$(RhetosDeploy)'=='True' And Exists('$(RhetosBuildCompleteFile)')"

--- a/Source/Rhetos.Extensibility/PluginScanner.cs
+++ b/Source/Rhetos.Extensibility/PluginScanner.cs
@@ -53,7 +53,7 @@ namespace Rhetos.Extensibility
                 () => GetPluginsByExport(findAssemblies),
                 LazyThreadSafetyMode.ExecutionAndPublication);
             _pluginScannerCache = new PluginScannerCache(cacheFolder, logProvider, new FilesUtility(logProvider));
-            _performanceLogger = logProvider.GetLogger("Performance");
+            _performanceLogger = logProvider.GetLogger("Performance." + GetType().Name);
             _logger = logProvider.GetLogger(GetType().Name);
 
             var ignoreList = pluginScannerOptions.PredefinedIgnoreAssemblyFiles.Concat(pluginScannerOptions.IgnoreAssemblyFiles ?? Array.Empty<string>()).Distinct().ToList();
@@ -154,7 +154,7 @@ namespace Rhetos.Extensibility
                 else
                     _logger.Trace(() => $"Searching for plugins in '{assembly}'");
 
-            _performanceLogger.Write(stopwatch, $"{nameof(PluginScanner)}: Listed assemblies ({assemblies.Count}).");
+            _performanceLogger.Write(stopwatch, $"Listed assemblies ({assemblies.Count}).");
             return assemblies;
         }
 
@@ -182,6 +182,7 @@ namespace Rhetos.Extensibility
                     }
                     else
                     {
+                        _logger.Trace($"Assembly '{assemblyPath}' is not cached. Scanning all types.");
                         exports = GetMefExportsForAssembly(assemblyPath);
                     }
 
@@ -215,7 +216,7 @@ namespace Rhetos.Extensibility
                 foreach (var pluginsGroup in pluginsByExport)
                     SortByDependency(pluginsGroup.Value);
 
-                _performanceLogger.Write(stopwatch, $"{nameof(PluginScanner)}: Loaded plugins ({pluginsCount}).");
+                _performanceLogger.Write(stopwatch, $"Loaded plugins ({pluginsCount}).");
 
                 return pluginsByExport;
             }

--- a/Source/Rhetos/Web.config
+++ b/Source/Rhetos/Web.config
@@ -38,7 +38,7 @@
       <!-- <logger name="ProcessingEngine CommandsWithClientError" minLevel="Trace" writeTo="TraceCommandsXml" /> -->
       <logger name="ProcessingEngine CommandsWithServerError" minLevel="Trace" writeTo="TraceCommandsXml" />
       <!-- <logger name="ProcessingEngine CommandsWithServerError" minLevel="Trace" writeTo="MainLog" /> -->
-      <!-- <logger name="Performance" minLevel="Trace" writeTo="PerformanceLog" /> -->
+      <!-- <logger name="Performance*" minLevel="Trace" writeTo="PerformanceLog" /> -->
     </rules>
   </nlog>
   <runtime>

--- a/Source/RhetosCli/App.config
+++ b/Source/RhetosCli/App.config
@@ -39,7 +39,7 @@
       <logger name="*" minLevel="Info" writeTo="ConsoleLog"/>
       <logger name="*" minLevel="Info" writeTo="MainLog"/>
       <logger name="DatabaseGeneratorChanges" level="Trace" writeTo="MainLog"/>
-      <logger name="Performance" minLevel="Trace" writeTo="PerformanceLog"/>
+      <logger name="Performance*" minLevel="Trace" writeTo="PerformanceLog"/>
       <!-- <logger name="*" minLevel="Trace" writeTo="TraceLog"/> -->
     </rules>
   </nlog>


### PR DESCRIPTION
1. Build cache was overriding runtime cache, but all assembly paths are different (cache comparison includes path).
2. Runtime cache was cleared on build because it was reported as generated file.