### PR TITLE
Assembly resolver and RhetosProcessContainer

### DIFF
--- a/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/AutoCodeCachedTest.cs
+++ b/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/AutoCodeCachedTest.cs
@@ -17,17 +17,16 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using CommonConcepts.Test.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Rhetos.Configuration.Autofac;
+using Rhetos.Dom.DefaultConcepts;
+using Rhetos.TestCommon;
+using Rhetos.Utilities;
 using System;
-using System.Text;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Rhetos.Dom.DefaultConcepts;
-using Rhetos.Configuration.Autofac;
-using Rhetos.Utilities;
-using Rhetos.TestCommon;
 using System.Threading.Tasks;
-using System.Diagnostics;
 
 namespace CommonConcepts.Test
 {
@@ -50,7 +49,7 @@ namespace CommonConcepts.Test
                 });
         }
 
-        private static void TestSimple(RhetosTestContainer container, Common.DomRepository repository, string format, string expectedCode)
+        private static void TestSimple(Common.DomRepository repository, string format, string expectedCode)
         {
             Guid id = Guid.NewGuid();
             repository.TestAutoCodeCached.Simple.Insert(new[] { new TestAutoCodeCached.Simple { ID = id, Code = format } });
@@ -60,7 +59,7 @@ namespace CommonConcepts.Test
             Assert.AreEqual(expectedCode, generatedCode);
         }
         
-        private static void TestDoubleAutoCode(RhetosTestContainer container, Common.DomRepository repository, string formatA, string formatB, string expectedCodes)
+        private static void TestDoubleAutoCode(Common.DomRepository repository, string formatA, string formatB, string expectedCodes)
         {
             Guid id = Guid.NewGuid();
             repository.TestAutoCodeCached.DoubleAutoCode.Insert(new[] { new TestAutoCodeCached.DoubleAutoCode { ID = id, CodeA = formatA, CodeB = formatB } });
@@ -72,7 +71,7 @@ namespace CommonConcepts.Test
             Assert.AreEqual(expectedCodes, generatedCodes);
         }
 
-        private static void TestDoubleAutoCodeWithGroup(RhetosTestContainer container, Common.DomRepository repository, string group, string formatA, string formatB, string expectedCodes)
+        private static void TestDoubleAutoCodeWithGroup(Common.DomRepository repository, string group, string formatA, string formatB, string expectedCodes)
         {
             Guid id = Guid.NewGuid();
             repository.TestAutoCodeCached.DoubleAutoCodeWithGroup.Insert(new[] { new TestAutoCodeCached.DoubleAutoCodeWithGroup { ID = id, Grouping = group, CodeA = formatA, CodeB = formatB } });
@@ -92,19 +91,19 @@ namespace CommonConcepts.Test
                 DeleteOldData(container);
                 var repository = container.Resolve<Common.DomRepository>();
 
-                TestSimple(container, repository, "+", "1");
-                TestSimple(container, repository, "+", "2");
-                TestSimple(container, repository, "+", "3");
-                TestSimple(container, repository, "9", "9");
-                TestSimple(container, repository, "+", "10");
-                TestSimple(container, repository, "+", "11");
-                TestSimple(container, repository, "AB+", "AB1");
-                TestSimple(container, repository, "X", "X");
-                TestSimple(container, repository, "X+", "X1");
-                TestSimple(container, repository, "AB007", "AB007");
-                TestSimple(container, repository, "AB+", "AB008");
-                TestSimple(container, repository, "AB999", "AB999");
-                TestSimple(container, repository, "AB+", "AB1000");
+                TestSimple(repository, "+", "1");
+                TestSimple(repository, "+", "2");
+                TestSimple(repository, "+", "3");
+                TestSimple(repository, "9", "9");
+                TestSimple(repository, "+", "10");
+                TestSimple(repository, "+", "11");
+                TestSimple(repository, "AB+", "AB1");
+                TestSimple(repository, "X", "X");
+                TestSimple(repository, "X+", "X1");
+                TestSimple(repository, "AB007", "AB007");
+                TestSimple(repository, "AB+", "AB008");
+                TestSimple(repository, "AB999", "AB999");
+                TestSimple(repository, "AB+", "AB1000");
             }
         }
 
@@ -154,14 +153,14 @@ namespace CommonConcepts.Test
                 DeleteOldData(container);
                 var repository = container.Resolve<Common.DomRepository>();
 
-                TestSimple(container, repository, "ab+", "ab1");
-                TestSimple(container, repository, "ab+", "ab2");
-                TestSimple(container, repository, "ab+", "ab3");
-                TestSimple(container, repository, "ab++++", "ab0004");
-                TestSimple(container, repository, "c+", "c1");
-                TestSimple(container, repository, "+", "1");
-                TestSimple(container, repository, "+", "2");
-                TestSimple(container, repository, "ab+", "ab0005");
+                TestSimple(repository, "ab+", "ab1");
+                TestSimple(repository, "ab+", "ab2");
+                TestSimple(repository, "ab+", "ab3");
+                TestSimple(repository, "ab++++", "ab0004");
+                TestSimple(repository, "c+", "c1");
+                TestSimple(repository, "+", "1");
+                TestSimple(repository, "+", "2");
+                TestSimple(repository, "ab+", "ab0005");
             }
         }
 
@@ -173,19 +172,19 @@ namespace CommonConcepts.Test
                 DeleteOldData(container);
                 var repository = container.Resolve<Common.DomRepository>();
 
-                TestDoubleAutoCode(container, repository, "+", "+", "1,1");
-                TestDoubleAutoCode(container, repository, "+", "4", "2,4");
-                TestDoubleAutoCode(container, repository, "+", "+", "3,5");
-                TestDoubleAutoCode(container, repository, "9", "+", "9,6");
-                TestDoubleAutoCode(container, repository, "+", "11", "10,11");
-                TestDoubleAutoCode(container, repository, "+", "+", "11,12");
-                TestDoubleAutoCode(container, repository, "AB+", "+", "AB1,13");
-                TestDoubleAutoCode(container, repository, "AB+", "X", "AB2,X");
-                TestDoubleAutoCode(container, repository, "AB+", "X+", "AB3,X1");
-                TestDoubleAutoCode(container, repository, "AB008", "X+", "AB008,X2");
-                TestDoubleAutoCode(container, repository, "AB+", "+", "AB009,14");
-                TestDoubleAutoCode(container, repository, "+", "AB9999", "12,AB9999");
-                TestDoubleAutoCode(container, repository, "AB+", "AB+", "AB010,AB10000");
+                TestDoubleAutoCode(repository, "+", "+", "1,1");
+                TestDoubleAutoCode(repository, "+", "4", "2,4");
+                TestDoubleAutoCode(repository, "+", "+", "3,5");
+                TestDoubleAutoCode(repository, "9", "+", "9,6");
+                TestDoubleAutoCode(repository, "+", "11", "10,11");
+                TestDoubleAutoCode(repository, "+", "+", "11,12");
+                TestDoubleAutoCode(repository, "AB+", "+", "AB1,13");
+                TestDoubleAutoCode(repository, "AB+", "X", "AB2,X");
+                TestDoubleAutoCode(repository, "AB+", "X+", "AB3,X1");
+                TestDoubleAutoCode(repository, "AB008", "X+", "AB008,X2");
+                TestDoubleAutoCode(repository, "AB+", "+", "AB009,14");
+                TestDoubleAutoCode(repository, "+", "AB9999", "12,AB9999");
+                TestDoubleAutoCode(repository, "AB+", "AB+", "AB010,AB10000");
             }
         }
 
@@ -197,26 +196,26 @@ namespace CommonConcepts.Test
                 DeleteOldData(container);
                 var repository = container.Resolve<Common.DomRepository>();
 
-                TestDoubleAutoCodeWithGroup(container, repository, "1", "+", "+", "1,1");
-                TestDoubleAutoCodeWithGroup(container, repository, "1", "+", "4", "2,4");
-                TestDoubleAutoCodeWithGroup(container, repository, "2", "+", "+", "3,1");
-                TestDoubleAutoCodeWithGroup(container, repository, "1", "9", "+", "9,5");
-                TestDoubleAutoCodeWithGroup(container, repository, "2", "+", "11", "10,11");
-                TestDoubleAutoCodeWithGroup(container, repository, "1", "+", "+", "11,6");
-                TestDoubleAutoCodeWithGroup(container, repository, "1", "AB+", "+", "AB1,7");
-                TestDoubleAutoCodeWithGroup(container, repository, "1", "AB+", "X", "AB2,X");
-                TestDoubleAutoCodeWithGroup(container, repository, "2", "AB+", "X09", "AB3,X09");
-                TestDoubleAutoCodeWithGroup(container, repository, "2", "AB+", "X+", "AB4,X10");
-                TestDoubleAutoCodeWithGroup(container, repository, "1", "AB+", "X+", "AB5,X1");
-                TestDoubleAutoCodeWithGroup(container, repository, "1", "AB008", "X+", "AB008,X2");
-                TestDoubleAutoCodeWithGroup(container, repository, "1", "AB+", "+", "AB009,8");
-                TestDoubleAutoCodeWithGroup(container, repository, "1", "+", "AB9999", "12,AB9999");
-                TestDoubleAutoCodeWithGroup(container, repository, "1", "AB+", "AB+", "AB010,AB10000");
+                TestDoubleAutoCodeWithGroup(repository, "1", "+", "+", "1,1");
+                TestDoubleAutoCodeWithGroup(repository, "1", "+", "4", "2,4");
+                TestDoubleAutoCodeWithGroup(repository, "2", "+", "+", "3,1");
+                TestDoubleAutoCodeWithGroup(repository, "1", "9", "+", "9,5");
+                TestDoubleAutoCodeWithGroup(repository, "2", "+", "11", "10,11");
+                TestDoubleAutoCodeWithGroup(repository, "1", "+", "+", "11,6");
+                TestDoubleAutoCodeWithGroup(repository, "1", "AB+", "+", "AB1,7");
+                TestDoubleAutoCodeWithGroup(repository, "1", "AB+", "X", "AB2,X");
+                TestDoubleAutoCodeWithGroup(repository, "2", "AB+", "X09", "AB3,X09");
+                TestDoubleAutoCodeWithGroup(repository, "2", "AB+", "X+", "AB4,X10");
+                TestDoubleAutoCodeWithGroup(repository, "1", "AB+", "X+", "AB5,X1");
+                TestDoubleAutoCodeWithGroup(repository, "1", "AB008", "X+", "AB008,X2");
+                TestDoubleAutoCodeWithGroup(repository, "1", "AB+", "+", "AB009,8");
+                TestDoubleAutoCodeWithGroup(repository, "1", "+", "AB9999", "12,AB9999");
+                TestDoubleAutoCodeWithGroup(repository, "1", "AB+", "AB+", "AB010,AB10000");
             }
         }
 
         private static void TestGroup<TEntity, TGroup>(
-            RhetosTestContainer container, IQueryableRepository<IEntity> entityRepository,
+            IQueryableRepository<IEntity> entityRepository,
             TGroup group, string format, string expectedCode)
                 where TEntity : class, IEntity, new()
         {
@@ -257,33 +256,33 @@ namespace CommonConcepts.Test
                 DeleteOldData(container);
                 var repository = container.Resolve<Common.DomRepository>();
 
-                TestGroup<TestAutoCodeCached.IntGroup, int>(container, repository.TestAutoCodeCached.IntGroup, 500, "+", "1");
-                TestGroup<TestAutoCodeCached.IntGroup, int>(container, repository.TestAutoCodeCached.IntGroup, 500, "+", "2");
-                TestGroup<TestAutoCodeCached.IntGroup, int>(container, repository.TestAutoCodeCached.IntGroup, 600, "+", "1");
-                TestGroup<TestAutoCodeCached.IntGroup, int>(container, repository.TestAutoCodeCached.IntGroup, 600, "A+", "A1");
+                TestGroup<TestAutoCodeCached.IntGroup, int>(repository.TestAutoCodeCached.IntGroup, 500, "+", "1");
+                TestGroup<TestAutoCodeCached.IntGroup, int>(repository.TestAutoCodeCached.IntGroup, 500, "+", "2");
+                TestGroup<TestAutoCodeCached.IntGroup, int>(repository.TestAutoCodeCached.IntGroup, 600, "+", "1");
+                TestGroup<TestAutoCodeCached.IntGroup, int>(repository.TestAutoCodeCached.IntGroup, 600, "A+", "A1");
 
-                TestGroup<TestAutoCodeCached.StringGroup, string>(container, repository.TestAutoCodeCached.StringGroup, "x", "+", "1");
-                TestGroup<TestAutoCodeCached.StringGroup, string>(container, repository.TestAutoCodeCached.StringGroup, "x", "+", "2");
-                TestGroup<TestAutoCodeCached.StringGroup, string>(container, repository.TestAutoCodeCached.StringGroup, "y", "+", "1");
-                TestGroup<TestAutoCodeCached.StringGroup, string>(container, repository.TestAutoCodeCached.StringGroup, "y", "A+", "A1");
+                TestGroup<TestAutoCodeCached.StringGroup, string>(repository.TestAutoCodeCached.StringGroup, "x", "+", "1");
+                TestGroup<TestAutoCodeCached.StringGroup, string>(repository.TestAutoCodeCached.StringGroup, "x", "+", "2");
+                TestGroup<TestAutoCodeCached.StringGroup, string>(repository.TestAutoCodeCached.StringGroup, "y", "+", "1");
+                TestGroup<TestAutoCodeCached.StringGroup, string>(repository.TestAutoCodeCached.StringGroup, "y", "A+", "A1");
 
                 var simple1 = new TestAutoCodeCached.Simple { ID = Guid.NewGuid(), Code = "1" };
                 var simple2 = new TestAutoCodeCached.Simple { ID = Guid.NewGuid(), Code = "2" };
                 repository.TestAutoCodeCached.Simple.Insert(new[] { simple1, simple2 });
 
-                TestGroup<TestAutoCodeCached.ReferenceGroup, TestAutoCodeCached.Simple>(container, repository.TestAutoCodeCached.ReferenceGroup, simple1, "+", "1");
-                TestGroup<TestAutoCodeCached.ReferenceGroup, TestAutoCodeCached.Simple>(container, repository.TestAutoCodeCached.ReferenceGroup, simple1, "+", "2");
-                TestGroup<TestAutoCodeCached.ReferenceGroup, TestAutoCodeCached.Simple>(container, repository.TestAutoCodeCached.ReferenceGroup, simple2, "+", "1");
-                TestGroup<TestAutoCodeCached.ReferenceGroup, TestAutoCodeCached.Simple>(container, repository.TestAutoCodeCached.ReferenceGroup, simple2, "A+", "A1");
+                TestGroup<TestAutoCodeCached.ReferenceGroup, TestAutoCodeCached.Simple>(repository.TestAutoCodeCached.ReferenceGroup, simple1, "+", "1");
+                TestGroup<TestAutoCodeCached.ReferenceGroup, TestAutoCodeCached.Simple>(repository.TestAutoCodeCached.ReferenceGroup, simple1, "+", "2");
+                TestGroup<TestAutoCodeCached.ReferenceGroup, TestAutoCodeCached.Simple>(repository.TestAutoCodeCached.ReferenceGroup, simple2, "+", "1");
+                TestGroup<TestAutoCodeCached.ReferenceGroup, TestAutoCodeCached.Simple>(repository.TestAutoCodeCached.ReferenceGroup, simple2, "A+", "A1");
 
                 var grouping1 = new TestAutoCodeCached.Grouping { ID = Guid.NewGuid(), Code = "1" };
                 var grouping2 = new TestAutoCodeCached.Grouping { ID = Guid.NewGuid(), Code = "2" };
                 repository.TestAutoCodeCached.Grouping.Insert(new[] { grouping1, grouping2 });
 
-                TestGroup<TestAutoCodeCached.ShortReferenceGroup, TestAutoCodeCached.Grouping>(container, repository.TestAutoCodeCached.ShortReferenceGroup, grouping1, "+", "1");
-                TestGroup<TestAutoCodeCached.ShortReferenceGroup, TestAutoCodeCached.Grouping>(container, repository.TestAutoCodeCached.ShortReferenceGroup, grouping1, "+", "2");
-                TestGroup<TestAutoCodeCached.ShortReferenceGroup, TestAutoCodeCached.Grouping>(container, repository.TestAutoCodeCached.ShortReferenceGroup, grouping2, "+", "1");
-                TestGroup<TestAutoCodeCached.ShortReferenceGroup, TestAutoCodeCached.Grouping>(container, repository.TestAutoCodeCached.ShortReferenceGroup, grouping2, "A+", "A1");
+                TestGroup<TestAutoCodeCached.ShortReferenceGroup, TestAutoCodeCached.Grouping>(repository.TestAutoCodeCached.ShortReferenceGroup, grouping1, "+", "1");
+                TestGroup<TestAutoCodeCached.ShortReferenceGroup, TestAutoCodeCached.Grouping>(repository.TestAutoCodeCached.ShortReferenceGroup, grouping1, "+", "2");
+                TestGroup<TestAutoCodeCached.ShortReferenceGroup, TestAutoCodeCached.Grouping>(repository.TestAutoCodeCached.ShortReferenceGroup, grouping2, "+", "1");
+                TestGroup<TestAutoCodeCached.ShortReferenceGroup, TestAutoCodeCached.Grouping>(repository.TestAutoCodeCached.ShortReferenceGroup, grouping2, "A+", "A1");
             }
         }
 
@@ -346,19 +345,19 @@ namespace CommonConcepts.Test
                 DeleteOldData(container);
                 var repository = container.Resolve<Common.DomRepository>();
 
-                TestSimple(container, repository, "+", "1");
-                TestSimple(container, repository, "+", "2");
-                TestSimple(container, repository, "++++", "0003");
-                TestSimple(container, repository, "+", "0004");
-                TestSimple(container, repository, "++", "0005");
-                TestSimple(container, repository, "AB+", "AB1");
-                TestSimple(container, repository, "X", "X");
-                TestSimple(container, repository, "X+", "X1");
-                TestSimple(container, repository, "AB007", "AB007");
-                TestSimple(container, repository, "AB+", "AB008");
-                TestSimple(container, repository, "AB999", "AB999");
-                TestSimple(container, repository, "AB+", "AB1000");
-                TestSimple(container, repository, "AB++++++", "AB001001");
+                TestSimple(repository, "+", "1");
+                TestSimple(repository, "+", "2");
+                TestSimple(repository, "++++", "0003");
+                TestSimple(repository, "+", "0004");
+                TestSimple(repository, "++", "0005");
+                TestSimple(repository, "AB+", "AB1");
+                TestSimple(repository, "X", "X");
+                TestSimple(repository, "X+", "X1");
+                TestSimple(repository, "AB007", "AB007");
+                TestSimple(repository, "AB+", "AB008");
+                TestSimple(repository, "AB999", "AB999");
+                TestSimple(repository, "AB+", "AB1000");
+                TestSimple(repository, "AB++++++", "AB001001");
             }
         }
 
@@ -370,20 +369,20 @@ namespace CommonConcepts.Test
                 DeleteOldData(container);
                 var repository = container.Resolve<Common.DomRepository>();
 
-                TestSimple(container, repository, "+++", "001");
-                TestSimple(container, repository, "+", "002");
+                TestSimple(repository, "+++", "001");
+                TestSimple(repository, "+", "002");
 
-                TestSimple(container, repository, "AB99", "AB99");
-                TestSimple(container, repository, "AB++", "AB100");
+                TestSimple(repository, "AB99", "AB99");
+                TestSimple(repository, "AB++", "AB100");
 
-                TestSimple(container, repository, "AB999", "AB999");
-                TestSimple(container, repository, "AB++++++", "AB001000");
+                TestSimple(repository, "AB999", "AB999");
+                TestSimple(repository, "AB++++++", "AB001000");
 
-                TestSimple(container, repository, "B999", "B999");
-                TestSimple(container, repository, "B++", "B1000");
+                TestSimple(repository, "B999", "B999");
+                TestSimple(repository, "B++", "B1000");
 
-                TestSimple(container, repository, "C500", "C500");
-                TestSimple(container, repository, "C++", "C501");
+                TestSimple(repository, "C500", "C500");
+                TestSimple(repository, "C++", "C501");
             }
         }
 
@@ -395,17 +394,17 @@ namespace CommonConcepts.Test
                 DeleteOldData(container);
                 var repository = container.Resolve<Common.DomRepository>();
 
-                TestSimple(container, repository, "002", "002");
-                TestSimple(container, repository, "55", "55");
-                TestSimple(container, repository, "+", "56");
+                TestSimple(repository, "002", "002");
+                TestSimple(repository, "55", "55");
+                TestSimple(repository, "+", "56");
 
-                TestSimple(container, repository, "A002", "A002");
-                TestSimple(container, repository, "A55", "A55");
-                TestSimple(container, repository, "A++", "A56");
+                TestSimple(repository, "A002", "A002");
+                TestSimple(repository, "A55", "A55");
+                TestSimple(repository, "A++", "A56");
 
-                TestSimple(container, repository, "C100", "C100");
-                TestSimple(container, repository, "C99", "C99");
-                TestSimple(container, repository, "C+", "C101");
+                TestSimple(repository, "C100", "C100");
+                TestSimple(repository, "C99", "C99");
+                TestSimple(repository, "C+", "C101");
             }
         }
 
@@ -580,7 +579,7 @@ namespace CommonConcepts.Test
             using (var container = new RhetosTestContainer(true))
             {
                 DeleteOldData(container);
-                CheckForParallelism(container.Resolve<ISqlExecuter>(), threadCount);
+                RhetosProcessHelper.CheckForParallelism(container.Resolve<ISqlExecuter>(), threadCount);
             }
 
             for (int test = 1; test <= testCount; test++)
@@ -608,28 +607,6 @@ namespace CommonConcepts.Test
                             c.Dispose();
                 }
             }
-        }
-
-        private void CheckForParallelism(ISqlExecuter sqlExecuter, int requiredNumberOfThreads)
-        {
-            string sqlDelay01 = "WAITFOR DELAY '00:00:00.100'";
-            var sqls = new[] { sqlDelay01 };
-            sqlExecuter.ExecuteSql(sqls); // Possible cold start.
-
-            var sw = Stopwatch.StartNew();
-            Parallel.For(0, requiredNumberOfThreads, x => { sqlExecuter.ExecuteSql(sqls, false); });
-            sw.Stop();
-
-            Console.WriteLine("CheckForParallelism: " + sw.ElapsedMilliseconds + " ms.");
-
-            if (sw.ElapsedMilliseconds < 50)
-                Assert.Fail("Delay is unexpectedly short: " + sw.ElapsedMilliseconds);
-
-            if (sw.Elapsed.TotalMilliseconds > 190)
-                Assert.Inconclusive(string.Format(
-                    "This test requires {0} parallel SQL queries. {0} parallel delays for 100 ms are executed in {1} ms.",
-                    requiredNumberOfThreads,
-                    sw.ElapsedMilliseconds));
         }
     }
 }

--- a/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/AutoCodeTest.cs
+++ b/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/AutoCodeTest.cs
@@ -17,19 +17,18 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-using System;
-using System.Text;
-using System.Collections.Generic;
-using System.Linq;
+using CommonConcepts.Test.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Rhetos.Dom.DefaultConcepts;
 using Rhetos.Configuration.Autofac;
-using Rhetos.Utilities;
+using Rhetos.Dom.DefaultConcepts;
 using Rhetos.TestCommon;
-using System.Threading.Tasks;
+using Rhetos.Utilities;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
-using System.Collections.Concurrent;
+using System.Threading.Tasks;
 
 namespace CommonConcepts.Test
 {
@@ -54,7 +53,7 @@ namespace CommonConcepts.Test
                 });
         }
 
-        private static void TestSimple(RhetosTestContainer container, Common.DomRepository repository, string format, string expectedCode)
+        private static void TestSimple(Common.DomRepository repository, string format, string expectedCode)
         {
             Guid id = Guid.NewGuid();
             repository.TestAutoCode.Simple.Insert(new[] { new TestAutoCode.Simple { ID = id, Code = format } });
@@ -64,7 +63,7 @@ namespace CommonConcepts.Test
             Assert.AreEqual(expectedCode, generatedCode);
         }
 
-        private static void TestIntAutoCode(RhetosTestContainer container, Common.DomRepository repository, int? input, int expectedCode)
+        private static void TestIntAutoCode(Common.DomRepository repository, int? input, int expectedCode)
         {
             Guid id = Guid.NewGuid();
             repository.TestAutoCode.IntegerAutoCode.Insert(new[] { new TestAutoCode.IntegerAutoCode { ID = id, Code = input } });
@@ -74,7 +73,7 @@ namespace CommonConcepts.Test
             Assert.AreEqual(expectedCode, generatedCode);
         }
 
-        private static void TestDoubleAutoCode(RhetosTestContainer container, Common.DomRepository repository, string formatA, string formatB, string expectedCodes)
+        private static void TestDoubleAutoCode(Common.DomRepository repository, string formatA, string formatB, string expectedCodes)
         {
             Guid id = Guid.NewGuid();
             repository.TestAutoCode.DoubleAutoCode.Insert(new[] { new TestAutoCode.DoubleAutoCode { ID = id, CodeA = formatA, CodeB = formatB } });
@@ -86,7 +85,7 @@ namespace CommonConcepts.Test
             Assert.AreEqual(expectedCodes, generatedCodes);
         }
 
-        private static void TestDoubleAutoCodeWithGroup(RhetosTestContainer container, Common.DomRepository repository, string group, string formatA, string formatB, string expectedCodes)
+        private static void TestDoubleAutoCodeWithGroup(Common.DomRepository repository, string group, string formatA, string formatB, string expectedCodes)
         {
             Guid id = Guid.NewGuid();
             repository.TestAutoCode.DoubleAutoCodeWithGroup.Insert(new[] { new TestAutoCode.DoubleAutoCodeWithGroup { ID = id, Grouping = group, CodeA = formatA, CodeB = formatB } });
@@ -98,7 +97,7 @@ namespace CommonConcepts.Test
             Assert.AreEqual(expectedCodes, generatedCodes);
         }
 
-        private static void TestDoubleIntegerAutoCodeWithGroup(RhetosTestContainer container, Common.DomRepository repository, int group, int? codeA, int? codeB, string expectedCodes)
+        private static void TestDoubleIntegerAutoCodeWithGroup(Common.DomRepository repository, int group, int? codeA, int? codeB, string expectedCodes)
         {
             Guid id = Guid.NewGuid();
             repository.TestAutoCode.IntegerAutoCodeForEach.Insert(new[] {
@@ -119,19 +118,19 @@ namespace CommonConcepts.Test
                 DeleteOldData(container);
                 var repository = container.Resolve<Common.DomRepository>();
 
-                TestSimple(container, repository, "+", "1");
-                TestSimple(container, repository, "+", "2");
-                TestSimple(container, repository, "+", "3");
-                TestSimple(container, repository, "9", "9");
-                TestSimple(container, repository, "+", "10");
-                TestSimple(container, repository, "+", "11");
-                TestSimple(container, repository, "AB+", "AB1");
-                TestSimple(container, repository, "X", "X");
-                TestSimple(container, repository, "X+", "X1");
-                TestSimple(container, repository, "AB007", "AB007");
-                TestSimple(container, repository, "AB+", "AB008");
-                TestSimple(container, repository, "AB999", "AB999");
-                TestSimple(container, repository, "AB+", "AB1000");
+                TestSimple(repository, "+", "1");
+                TestSimple(repository, "+", "2");
+                TestSimple(repository, "+", "3");
+                TestSimple(repository, "9", "9");
+                TestSimple(repository, "+", "10");
+                TestSimple(repository, "+", "11");
+                TestSimple(repository, "AB+", "AB1");
+                TestSimple(repository, "X", "X");
+                TestSimple(repository, "X+", "X1");
+                TestSimple(repository, "AB007", "AB007");
+                TestSimple(repository, "AB+", "AB008");
+                TestSimple(repository, "AB999", "AB999");
+                TestSimple(repository, "AB+", "AB1000");
             }
         }
 
@@ -181,14 +180,14 @@ namespace CommonConcepts.Test
                 DeleteOldData(container);
                 var repository = container.Resolve<Common.DomRepository>();
 
-                TestSimple(container, repository, "ab+", "ab1");
-                TestSimple(container, repository, "ab+", "ab2");
-                TestSimple(container, repository, "ab+", "ab3");
-                TestSimple(container, repository, "ab++++", "ab0004");
-                TestSimple(container, repository, "c+", "c1");
-                TestSimple(container, repository, "+", "1");
-                TestSimple(container, repository, "+", "2");
-                TestSimple(container, repository, "ab+", "ab0005");
+                TestSimple(repository, "ab+", "ab1");
+                TestSimple(repository, "ab+", "ab2");
+                TestSimple(repository, "ab+", "ab3");
+                TestSimple(repository, "ab++++", "ab0004");
+                TestSimple(repository, "c+", "c1");
+                TestSimple(repository, "+", "1");
+                TestSimple(repository, "+", "2");
+                TestSimple(repository, "ab+", "ab0005");
             }
         }
 
@@ -200,19 +199,19 @@ namespace CommonConcepts.Test
                 DeleteOldData(container);
                 var repository = container.Resolve<Common.DomRepository>();
 
-                TestDoubleAutoCode(container, repository, "+", "+", "1,1");
-                TestDoubleAutoCode(container, repository, "+", "4", "2,4");
-                TestDoubleAutoCode(container, repository, "+", "+", "3,5");
-                TestDoubleAutoCode(container, repository, "9", "+", "9,6");
-                TestDoubleAutoCode(container, repository, "+", "11", "10,11");
-                TestDoubleAutoCode(container, repository, "+", "+", "11,12");
-                TestDoubleAutoCode(container, repository, "AB+", "+", "AB1,13");
-                TestDoubleAutoCode(container, repository, "AB+", "X", "AB2,X");
-                TestDoubleAutoCode(container, repository, "AB+", "X+", "AB3,X1");
-                TestDoubleAutoCode(container, repository, "AB008", "X+", "AB008,X2");
-                TestDoubleAutoCode(container, repository, "AB+", "+", "AB009,14");
-                TestDoubleAutoCode(container, repository, "+", "AB9999", "12,AB9999");
-                TestDoubleAutoCode(container, repository, "AB+", "AB+", "AB010,AB10000");
+                TestDoubleAutoCode(repository, "+", "+", "1,1");
+                TestDoubleAutoCode(repository, "+", "4", "2,4");
+                TestDoubleAutoCode(repository, "+", "+", "3,5");
+                TestDoubleAutoCode(repository, "9", "+", "9,6");
+                TestDoubleAutoCode(repository, "+", "11", "10,11");
+                TestDoubleAutoCode(repository, "+", "+", "11,12");
+                TestDoubleAutoCode(repository, "AB+", "+", "AB1,13");
+                TestDoubleAutoCode(repository, "AB+", "X", "AB2,X");
+                TestDoubleAutoCode(repository, "AB+", "X+", "AB3,X1");
+                TestDoubleAutoCode(repository, "AB008", "X+", "AB008,X2");
+                TestDoubleAutoCode(repository, "AB+", "+", "AB009,14");
+                TestDoubleAutoCode(repository, "+", "AB9999", "12,AB9999");
+                TestDoubleAutoCode(repository, "AB+", "AB+", "AB010,AB10000");
             }
         }
 
@@ -224,13 +223,13 @@ namespace CommonConcepts.Test
                 DeleteOldData(container);
                 var repository = container.Resolve<Common.DomRepository>();
 
-                TestIntAutoCode(container, repository, 0, 1);
-                TestIntAutoCode(container, repository, 10, 10);
-                TestIntAutoCode(container, repository, 0, 11);
-                TestIntAutoCode(container, repository, 99, 99);
-                TestIntAutoCode(container, repository, 0, 100);
-                TestIntAutoCode(container, repository, 0, 101);
-                TestIntAutoCode(container, repository, 0, 102);
+                TestIntAutoCode(repository, 0, 1);
+                TestIntAutoCode(repository, 10, 10);
+                TestIntAutoCode(repository, 0, 11);
+                TestIntAutoCode(repository, 99, 99);
+                TestIntAutoCode(repository, 0, 100);
+                TestIntAutoCode(repository, 0, 101);
+                TestIntAutoCode(repository, 0, 102);
             }
         }
 
@@ -242,8 +241,8 @@ namespace CommonConcepts.Test
                 DeleteOldData(container);
                 var repository = container.Resolve<Common.DomRepository>();
 
-                TestIntAutoCode(container, repository, null, 1);
-                TestIntAutoCode(container, repository, null, 2);
+                TestIntAutoCode(repository, null, 1);
+                TestIntAutoCode(repository, null, 2);
             }
         }
 
@@ -255,21 +254,21 @@ namespace CommonConcepts.Test
                 DeleteOldData(container);
                 var repository = container.Resolve<Common.DomRepository>();
 
-                TestDoubleAutoCodeWithGroup(container, repository, "1", "+", "+", "1,1");
-                TestDoubleAutoCodeWithGroup(container, repository, "1", "+", "4", "2,4");
-                TestDoubleAutoCodeWithGroup(container, repository, "2", "+", "+", "3,1");
-                TestDoubleAutoCodeWithGroup(container, repository, "1", "9", "+", "9,5");
-                TestDoubleAutoCodeWithGroup(container, repository, "2", "+", "11", "10,11");
-                TestDoubleAutoCodeWithGroup(container, repository, "1", "+", "+", "11,6");
-                TestDoubleAutoCodeWithGroup(container, repository, "1", "AB+", "+", "AB1,7");
-                TestDoubleAutoCodeWithGroup(container, repository, "1", "AB+", "X", "AB2,X");
-                TestDoubleAutoCodeWithGroup(container, repository, "2", "AB+", "X09", "AB3,X09");
-                TestDoubleAutoCodeWithGroup(container, repository, "2", "AB+", "X+", "AB4,X10");
-                TestDoubleAutoCodeWithGroup(container, repository, "1", "AB+", "X+", "AB5,X1");
-                TestDoubleAutoCodeWithGroup(container, repository, "1", "AB008", "X+", "AB008,X2");
-                TestDoubleAutoCodeWithGroup(container, repository, "1", "AB+", "+", "AB009,8");
-                TestDoubleAutoCodeWithGroup(container, repository, "1", "+", "AB9999", "12,AB9999");
-                TestDoubleAutoCodeWithGroup(container, repository, "1", "AB+", "AB+", "AB010,AB10000");
+                TestDoubleAutoCodeWithGroup(repository, "1", "+", "+", "1,1");
+                TestDoubleAutoCodeWithGroup(repository, "1", "+", "4", "2,4");
+                TestDoubleAutoCodeWithGroup(repository, "2", "+", "+", "3,1");
+                TestDoubleAutoCodeWithGroup(repository, "1", "9", "+", "9,5");
+                TestDoubleAutoCodeWithGroup(repository, "2", "+", "11", "10,11");
+                TestDoubleAutoCodeWithGroup(repository, "1", "+", "+", "11,6");
+                TestDoubleAutoCodeWithGroup(repository, "1", "AB+", "+", "AB1,7");
+                TestDoubleAutoCodeWithGroup(repository, "1", "AB+", "X", "AB2,X");
+                TestDoubleAutoCodeWithGroup(repository, "2", "AB+", "X09", "AB3,X09");
+                TestDoubleAutoCodeWithGroup(repository, "2", "AB+", "X+", "AB4,X10");
+                TestDoubleAutoCodeWithGroup(repository, "1", "AB+", "X+", "AB5,X1");
+                TestDoubleAutoCodeWithGroup(repository, "1", "AB008", "X+", "AB008,X2");
+                TestDoubleAutoCodeWithGroup(repository, "1", "AB+", "+", "AB009,8");
+                TestDoubleAutoCodeWithGroup(repository, "1", "+", "AB9999", "12,AB9999");
+                TestDoubleAutoCodeWithGroup(repository, "1", "AB+", "AB+", "AB010,AB10000");
             }
         }
 
@@ -281,12 +280,12 @@ namespace CommonConcepts.Test
                 var repository = container.Resolve<Common.DomRepository>();
                 repository.TestAutoCode.IntegerAutoCodeForEach.Delete(repository.TestAutoCode.IntegerAutoCodeForEach.Query());
 
-                TestDoubleIntegerAutoCodeWithGroup(container, repository, 1, 0, 0, "1,1");
-                TestDoubleIntegerAutoCodeWithGroup(container, repository, 1, 5, 0, "5,2");
-                TestDoubleIntegerAutoCodeWithGroup(container, repository, 1, 0, 0, "6,3");
-                TestDoubleIntegerAutoCodeWithGroup(container, repository, 2, 8, 0, "8,1");
-                TestDoubleIntegerAutoCodeWithGroup(container, repository, 2, 0, 0, "9,2");
-                TestDoubleIntegerAutoCodeWithGroup(container, repository, 1, 0, 0, "10,4");
+                TestDoubleIntegerAutoCodeWithGroup(repository, 1, 0, 0, "1,1");
+                TestDoubleIntegerAutoCodeWithGroup(repository, 1, 5, 0, "5,2");
+                TestDoubleIntegerAutoCodeWithGroup(repository, 1, 0, 0, "6,3");
+                TestDoubleIntegerAutoCodeWithGroup(repository, 2, 8, 0, "8,1");
+                TestDoubleIntegerAutoCodeWithGroup(repository, 2, 0, 0, "9,2");
+                TestDoubleIntegerAutoCodeWithGroup(repository, 1, 0, 0, "10,4");
             }
         }
 
@@ -298,17 +297,17 @@ namespace CommonConcepts.Test
                 var repository = container.Resolve<Common.DomRepository>();
                 repository.TestAutoCode.IntegerAutoCodeForEach.Delete(repository.TestAutoCode.IntegerAutoCodeForEach.Query());
 
-                TestDoubleIntegerAutoCodeWithGroup(container, repository, 1, null, null, "1,1");
-                TestDoubleIntegerAutoCodeWithGroup(container, repository, 1, 5, null, "5,2");
-                TestDoubleIntegerAutoCodeWithGroup(container, repository, 1, null, null, "6,3");
-                TestDoubleIntegerAutoCodeWithGroup(container, repository, 2, 8, null, "8,1");
-                TestDoubleIntegerAutoCodeWithGroup(container, repository, 2, null, null, "9,2");
-                TestDoubleIntegerAutoCodeWithGroup(container, repository, 1, null, null, "10,4");
+                TestDoubleIntegerAutoCodeWithGroup(repository, 1, null, null, "1,1");
+                TestDoubleIntegerAutoCodeWithGroup(repository, 1, 5, null, "5,2");
+                TestDoubleIntegerAutoCodeWithGroup(repository, 1, null, null, "6,3");
+                TestDoubleIntegerAutoCodeWithGroup(repository, 2, 8, null, "8,1");
+                TestDoubleIntegerAutoCodeWithGroup(repository, 2, null, null, "9,2");
+                TestDoubleIntegerAutoCodeWithGroup(repository, 1, null, null, "10,4");
             }
         }
 
         private static void TestGroup<TEntity, TGroup>(
-            RhetosTestContainer container, IQueryableRepository<IEntity> entityRepository,
+            IQueryableRepository<IEntity> entityRepository,
             TGroup group, string format, string expectedCode)
                 where TEntity : class, IEntity, new()
         {
@@ -349,43 +348,43 @@ namespace CommonConcepts.Test
                 DeleteOldData(container);
                 var repository = container.Resolve<Common.DomRepository>();
 
-                TestGroup<TestAutoCode.IntGroup, int>(container, repository.TestAutoCode.IntGroup, 500, "+", "1");
-                TestGroup<TestAutoCode.IntGroup, int>(container, repository.TestAutoCode.IntGroup, 500, "+", "2");
-                TestGroup<TestAutoCode.IntGroup, int>(container, repository.TestAutoCode.IntGroup, 600, "+", "1");
-                TestGroup<TestAutoCode.IntGroup, int>(container, repository.TestAutoCode.IntGroup, 600, "A+", "A1");
-                TestGroup<TestAutoCode.IntGroup, int>(container, repository.TestAutoCode.IntGroup, 600, "A+", "A2");
+                TestGroup<TestAutoCode.IntGroup, int>(repository.TestAutoCode.IntGroup, 500, "+", "1");
+                TestGroup<TestAutoCode.IntGroup, int>(repository.TestAutoCode.IntGroup, 500, "+", "2");
+                TestGroup<TestAutoCode.IntGroup, int>(repository.TestAutoCode.IntGroup, 600, "+", "1");
+                TestGroup<TestAutoCode.IntGroup, int>(repository.TestAutoCode.IntGroup, 600, "A+", "A1");
+                TestGroup<TestAutoCode.IntGroup, int>(repository.TestAutoCode.IntGroup, 600, "A+", "A2");
 
-                TestGroup<TestAutoCode.BoolGroup, bool>(container, repository.TestAutoCode.BoolGroup, false, "+", "1");
-                TestGroup<TestAutoCode.BoolGroup, bool>(container, repository.TestAutoCode.BoolGroup, false, "+", "2");
-                TestGroup<TestAutoCode.BoolGroup, bool>(container, repository.TestAutoCode.BoolGroup, true, "+", "1");
-                TestGroup<TestAutoCode.BoolGroup, bool>(container, repository.TestAutoCode.BoolGroup, true, "A+", "A1");
-                TestGroup<TestAutoCode.BoolGroup, bool>(container, repository.TestAutoCode.BoolGroup, true, "A+", "A2");
+                TestGroup<TestAutoCode.BoolGroup, bool>(repository.TestAutoCode.BoolGroup, false, "+", "1");
+                TestGroup<TestAutoCode.BoolGroup, bool>(repository.TestAutoCode.BoolGroup, false, "+", "2");
+                TestGroup<TestAutoCode.BoolGroup, bool>(repository.TestAutoCode.BoolGroup, true, "+", "1");
+                TestGroup<TestAutoCode.BoolGroup, bool>(repository.TestAutoCode.BoolGroup, true, "A+", "A1");
+                TestGroup<TestAutoCode.BoolGroup, bool>(repository.TestAutoCode.BoolGroup, true, "A+", "A2");
 
-                TestGroup<TestAutoCode.StringGroup, string>(container, repository.TestAutoCode.StringGroup, "x", "+", "1");
-                TestGroup<TestAutoCode.StringGroup, string>(container, repository.TestAutoCode.StringGroup, "x", "+", "2");
-                TestGroup<TestAutoCode.StringGroup, string>(container, repository.TestAutoCode.StringGroup, "y", "+", "1");
-                TestGroup<TestAutoCode.StringGroup, string>(container, repository.TestAutoCode.StringGroup, "y", "A+", "A1");
-                TestGroup<TestAutoCode.StringGroup, string>(container, repository.TestAutoCode.StringGroup, "y", "A+", "A2");
+                TestGroup<TestAutoCode.StringGroup, string>(repository.TestAutoCode.StringGroup, "x", "+", "1");
+                TestGroup<TestAutoCode.StringGroup, string>(repository.TestAutoCode.StringGroup, "x", "+", "2");
+                TestGroup<TestAutoCode.StringGroup, string>(repository.TestAutoCode.StringGroup, "y", "+", "1");
+                TestGroup<TestAutoCode.StringGroup, string>(repository.TestAutoCode.StringGroup, "y", "A+", "A1");
+                TestGroup<TestAutoCode.StringGroup, string>(repository.TestAutoCode.StringGroup, "y", "A+", "A2");
 
                 var simple1 = new TestAutoCode.Simple { ID = Guid.NewGuid(), Code = "1" };
                 var simple2 = new TestAutoCode.Simple { ID = Guid.NewGuid(), Code = "2" };
                 repository.TestAutoCode.Simple.Insert(new[] { simple1, simple2 });
 
-                TestGroup<TestAutoCode.ReferenceGroup, TestAutoCode.Simple>(container, repository.TestAutoCode.ReferenceGroup, simple1, "+", "1");
-                TestGroup<TestAutoCode.ReferenceGroup, TestAutoCode.Simple>(container, repository.TestAutoCode.ReferenceGroup, simple1, "+", "2");
-                TestGroup<TestAutoCode.ReferenceGroup, TestAutoCode.Simple>(container, repository.TestAutoCode.ReferenceGroup, simple2, "+", "1");
-                TestGroup<TestAutoCode.ReferenceGroup, TestAutoCode.Simple>(container, repository.TestAutoCode.ReferenceGroup, simple2, "A+", "A1");
-                TestGroup<TestAutoCode.ReferenceGroup, TestAutoCode.Simple>(container, repository.TestAutoCode.ReferenceGroup, simple2, "A+", "A2");
+                TestGroup<TestAutoCode.ReferenceGroup, TestAutoCode.Simple>(repository.TestAutoCode.ReferenceGroup, simple1, "+", "1");
+                TestGroup<TestAutoCode.ReferenceGroup, TestAutoCode.Simple>(repository.TestAutoCode.ReferenceGroup, simple1, "+", "2");
+                TestGroup<TestAutoCode.ReferenceGroup, TestAutoCode.Simple>(repository.TestAutoCode.ReferenceGroup, simple2, "+", "1");
+                TestGroup<TestAutoCode.ReferenceGroup, TestAutoCode.Simple>(repository.TestAutoCode.ReferenceGroup, simple2, "A+", "A1");
+                TestGroup<TestAutoCode.ReferenceGroup, TestAutoCode.Simple>(repository.TestAutoCode.ReferenceGroup, simple2, "A+", "A2");
 
                 var grouping1 = new TestAutoCode.Grouping { ID = Guid.NewGuid(), Code = "1" };
                 var grouping2 = new TestAutoCode.Grouping { ID = Guid.NewGuid(), Code = "2" };
                 repository.TestAutoCode.Grouping.Insert(new[] { grouping1, grouping2 });
 
-                TestGroup<TestAutoCode.ShortReferenceGroup, TestAutoCode.Grouping>(container, repository.TestAutoCode.ShortReferenceGroup, grouping1, "+", "1");
-                TestGroup<TestAutoCode.ShortReferenceGroup, TestAutoCode.Grouping>(container, repository.TestAutoCode.ShortReferenceGroup, grouping1, "+", "2");
-                TestGroup<TestAutoCode.ShortReferenceGroup, TestAutoCode.Grouping>(container, repository.TestAutoCode.ShortReferenceGroup, grouping2, "+", "1");
-                TestGroup<TestAutoCode.ShortReferenceGroup, TestAutoCode.Grouping>(container, repository.TestAutoCode.ShortReferenceGroup, grouping2, "A+", "A1");
-                TestGroup<TestAutoCode.ShortReferenceGroup, TestAutoCode.Grouping>(container, repository.TestAutoCode.ShortReferenceGroup, grouping2, "A+", "A2");
+                TestGroup<TestAutoCode.ShortReferenceGroup, TestAutoCode.Grouping>(repository.TestAutoCode.ShortReferenceGroup, grouping1, "+", "1");
+                TestGroup<TestAutoCode.ShortReferenceGroup, TestAutoCode.Grouping>(repository.TestAutoCode.ShortReferenceGroup, grouping1, "+", "2");
+                TestGroup<TestAutoCode.ShortReferenceGroup, TestAutoCode.Grouping>(repository.TestAutoCode.ShortReferenceGroup, grouping2, "+", "1");
+                TestGroup<TestAutoCode.ShortReferenceGroup, TestAutoCode.Grouping>(repository.TestAutoCode.ShortReferenceGroup, grouping2, "A+", "A1");
+                TestGroup<TestAutoCode.ShortReferenceGroup, TestAutoCode.Grouping>(repository.TestAutoCode.ShortReferenceGroup, grouping2, "A+", "A2");
             }
         }
 
@@ -448,19 +447,19 @@ namespace CommonConcepts.Test
                 DeleteOldData(container);
                 var repository = container.Resolve<Common.DomRepository>();
 
-                TestSimple(container, repository, "+", "1");
-                TestSimple(container, repository, "+", "2");
-                TestSimple(container, repository, "++++", "0003");
-                TestSimple(container, repository, "+", "0004");
-                TestSimple(container, repository, "++", "0005");
-                TestSimple(container, repository, "AB+", "AB1");
-                TestSimple(container, repository, "X", "X");
-                TestSimple(container, repository, "X+", "X1");
-                TestSimple(container, repository, "AB007", "AB007");
-                TestSimple(container, repository, "AB+", "AB008");
-                TestSimple(container, repository, "AB999", "AB999");
-                TestSimple(container, repository, "AB+", "AB1000");
-                TestSimple(container, repository, "AB++++++", "AB001001");
+                TestSimple(repository, "+", "1");
+                TestSimple(repository, "+", "2");
+                TestSimple(repository, "++++", "0003");
+                TestSimple(repository, "+", "0004");
+                TestSimple(repository, "++", "0005");
+                TestSimple(repository, "AB+", "AB1");
+                TestSimple(repository, "X", "X");
+                TestSimple(repository, "X+", "X1");
+                TestSimple(repository, "AB007", "AB007");
+                TestSimple(repository, "AB+", "AB008");
+                TestSimple(repository, "AB999", "AB999");
+                TestSimple(repository, "AB+", "AB1000");
+                TestSimple(repository, "AB++++++", "AB001001");
             }
         }
 
@@ -472,20 +471,20 @@ namespace CommonConcepts.Test
                 DeleteOldData(container);
                 var repository = container.Resolve<Common.DomRepository>();
 
-                TestSimple(container, repository, "+++", "001");
-                TestSimple(container, repository, "+", "002");
+                TestSimple(repository, "+++", "001");
+                TestSimple(repository, "+", "002");
 
-                TestSimple(container, repository, "AB99", "AB99");
-                TestSimple(container, repository, "AB++", "AB100");
+                TestSimple(repository, "AB99", "AB99");
+                TestSimple(repository, "AB++", "AB100");
 
-                TestSimple(container, repository, "AB999", "AB999");
-                TestSimple(container, repository, "AB++++++", "AB001000");
+                TestSimple(repository, "AB999", "AB999");
+                TestSimple(repository, "AB++++++", "AB001000");
 
-                TestSimple(container, repository, "B999", "B999");
-                TestSimple(container, repository, "B++", "B1000");
+                TestSimple(repository, "B999", "B999");
+                TestSimple(repository, "B++", "B1000");
 
-                TestSimple(container, repository, "C500", "C500");
-                TestSimple(container, repository, "C++", "C501");
+                TestSimple(repository, "C500", "C500");
+                TestSimple(repository, "C++", "C501");
             }
         }
 
@@ -497,17 +496,17 @@ namespace CommonConcepts.Test
                 DeleteOldData(container);
                 var repository = container.Resolve<Common.DomRepository>();
 
-                TestSimple(container, repository, "002", "002");
-                TestSimple(container, repository, "55", "55");
-                TestSimple(container, repository, "+", "56");
+                TestSimple(repository, "002", "002");
+                TestSimple(repository, "55", "55");
+                TestSimple(repository, "+", "56");
 
-                TestSimple(container, repository, "A002", "A002");
-                TestSimple(container, repository, "A55", "A55");
-                TestSimple(container, repository, "A++", "A56");
+                TestSimple(repository, "A002", "A002");
+                TestSimple(repository, "A55", "A55");
+                TestSimple(repository, "A++", "A56");
 
-                TestSimple(container, repository, "C100", "C100");
-                TestSimple(container, repository, "C99", "C99");
-                TestSimple(container, repository, "C+", "C101");
+                TestSimple(repository, "C100", "C100");
+                TestSimple(repository, "C99", "C99");
+                TestSimple(repository, "C+", "C101");
             }
         }
 
@@ -682,7 +681,7 @@ namespace CommonConcepts.Test
 
             using (var container = new RhetosTestContainer(true))
             {
-                CheckForParallelism(container.Resolve<ISqlExecuter>(), threadCount);
+                RhetosProcessHelper.CheckForParallelism(container.Resolve<ISqlExecuter>(), threadCount);
                 DeleteOldData(container);
             }
 
@@ -774,7 +773,7 @@ namespace CommonConcepts.Test
             using (var container = new RhetosTestContainer(true))
             {
                 var sqlExecuter = container.Resolve<ISqlExecuter>();
-                CheckForParallelism(sqlExecuter, threadCount);
+                RhetosProcessHelper.CheckForParallelism(sqlExecuter, threadCount);
                 DeleteOldData(container);
 
                 coldStartInsert(container.Resolve<Common.ExecutionContext>());
@@ -819,29 +818,6 @@ namespace CommonConcepts.Test
                 Console.WriteLine("Exception " + x + ": " + exceptions[x] + ".");
             return exceptions;
         }
-
-        private void CheckForParallelism(ISqlExecuter sqlExecuter, int requiredNumberOfThreads)
-        {
-            string sqlDelay01 = "WAITFOR DELAY '00:00:00.100'";
-            var sqls = new[] { sqlDelay01 };
-            sqlExecuter.ExecuteSql(sqls); // Possible cold start.
-
-            var sw = Stopwatch.StartNew();
-            Parallel.For(0, requiredNumberOfThreads, x => { sqlExecuter.ExecuteSql(sqls, false); });
-            sw.Stop();
-
-            Console.WriteLine("CheckForParallelism: " + sw.ElapsedMilliseconds + " ms.");
-
-            if (sw.ElapsedMilliseconds < 50)
-                Assert.Fail("Delay is unexpectedly short: " + sw.ElapsedMilliseconds);
-
-            if (sw.Elapsed.TotalMilliseconds > 190)
-                Assert.Inconclusive(string.Format(
-                    "This test requires {0} parallel SQL queries. {0} parallel delays for 100 ms are executed in {1} ms.",
-                    requiredNumberOfThreads,
-                    sw.ElapsedMilliseconds));
-        }
-
 
         /// <summary>
         /// There is no need to lock all inserts. It should be allowed to insert different groups in parallel.

--- a/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/CommonConcepts.Test.csproj
+++ b/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/CommonConcepts.Test.csproj
@@ -171,6 +171,8 @@
     <Compile Include="AuthorizationCachingTest.cs" />
     <Compile Include="CreatedByTest.cs" />
     <Compile Include="DataMigrationTest.cs" />
+    <Compile Include="Helpers\RhetosProcessHelper.cs" />
+    <Compile Include="RhetosTransactionScopeContainerTest.cs" />
     <Compile Include="HardcodedEntityTest.cs" />
     <Compile Include="Helpers\PrincipalHelper.cs" />
     <Compile Include="EFOptimizationTest.cs" />

--- a/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/Helpers/RhetosProcessHelper.cs
+++ b/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/Helpers/RhetosProcessHelper.cs
@@ -40,9 +40,7 @@ namespace CommonConcepts.Test.Helpers
         /// The CreateTransactionScope() method and the created child container are thread safe.
         /// The child container represents a single database transaction (unit of work). Its transaction will be rolled back by default, see <see cref="RhetosTransactionScopeContainer.CommitChanges"/>.
         /// </summary>
-        public static RhetosProcessContainer Container = new RhetosProcessContainer(
-            applicationFolder: FindRhetosApplicationFolder(),
-            addCustomConfiguration: configurationBuilder => configurationBuilder.AddConfigurationManagerConfiguration());
+        public static RhetosProcessContainer Container = new RhetosProcessContainer(FindRhetosApplicationFolder());
 
         /// <summary>
         /// Unit tests can be executed at different disk locations depending on whether they are run at the solution or project level, from Visual Studio or another utility.

--- a/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/Helpers/RhetosProcessHelper.cs
+++ b/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/Helpers/RhetosProcessHelper.cs
@@ -1,0 +1,101 @@
+﻿/*
+    Copyright (C) 2014 Omega software d.o.o.
+
+    This file is part of Rhetos.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Rhetos;
+using Rhetos.Configuration.Autofac;
+using Rhetos.Utilities;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CommonConcepts.Test.Helpers
+{
+    /// <summary>
+    /// Helper class for unit tests.
+    /// </summary>
+    public static class RhetosProcessHelper
+    {
+        /// <summary>
+        /// Shared DI container to be reused between tests, to reduce initialization time for each test.
+        /// Each test should create a child container with 'RhetosProcessHelper.Container.CreateTransactionScope()' to start a 'using' block.
+        /// The CreateTransactionScope() method and the created child container are thread safe.
+        /// The child container represents a single database transaction (unit of work). Its transaction will be rolled back by default, see <see cref="RhetosTransactionScopeContainer.CommitChanges"/>.
+        /// </summary>
+        public static RhetosProcessContainer Container = new RhetosProcessContainer(
+            applicationFolder: FindRhetosApplicationFolder,
+            addCustomConfiguration: configurationBuilder => configurationBuilder.AddConfigurationManagerConfiguration());
+
+        private static string FindRhetosApplicationFolder()
+        {
+            var folder = new DirectoryInfo(Environment.CurrentDirectory);
+
+            if (IsValidRhetosServerDirectory(folder.FullName))
+                return folder.FullName;
+
+            // Unit testing subfolder.
+            if (folder.Name == "Out")
+                folder = folder.Parent.Parent.Parent;
+
+            // Unit testing at project level, not at solution level. It depends on the way the testing has been started.
+            if (folder.Name == "Debug")
+                folder = folder.Parent.Parent.Parent.Parent.Parent; // Climbing up CommonConcepts\CommonConceptsTest\CommonConcepts.Test\bin\Debug.
+
+            if (folder.GetDirectories().Any(subDir => subDir.Name == "Source"))
+                folder = new DirectoryInfo(Path.Combine(folder.FullName, @".\Source\Rhetos\"));
+
+            // For unit tests, project's source folder name is ".\Source\Rhetos".
+            if (folder.Name == "Rhetos" && IsValidRhetosServerDirectory(folder.FullName))
+                return folder.FullName;
+
+            throw new FrameworkException("Cannot locate a valid Rhetos server's folder from '" + Environment.CurrentDirectory + "'. Unexpected folder '" + folder.FullName + "'.");
+        }
+
+        private static bool IsValidRhetosServerDirectory(string path)
+        {
+            return
+                File.Exists(Path.Combine(path, @"Web.config"))
+                && File.Exists(Path.Combine(path, @"bin\Rhetos.Utilities.dll"));
+        }
+
+        public static void CheckForParallelism(ISqlExecuter sqlExecuter, int requiredNumberOfThreads)
+        {
+            string sqlDelay01 = "WAITFOR DELAY '00:00:00.100'";
+            var sqls = new[] { sqlDelay01 };
+            sqlExecuter.ExecuteSql(sqls); // Possible cold start.
+
+            var sw = Stopwatch.StartNew();
+            Parallel.For(0, requiredNumberOfThreads, x => { sqlExecuter.ExecuteSql(sqls, false); });
+            sw.Stop();
+
+            Console.WriteLine("CheckForParallelism: " + sw.ElapsedMilliseconds + " ms.");
+
+            if (sw.ElapsedMilliseconds < 50)
+                Assert.Fail("Delay is unexpectedly short: " + sw.ElapsedMilliseconds);
+
+            if (sw.Elapsed.TotalMilliseconds > 190)
+                Assert.Inconclusive(string.Format(
+                    "This test requires {0} parallel SQL queries. {0} parallel delays for 100 ms are executed in {1} ms.",
+                    requiredNumberOfThreads,
+                    sw.ElapsedMilliseconds));
+        }
+    }
+}

--- a/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/RhetosTransactionScopeContainerTest.cs
+++ b/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/RhetosTransactionScopeContainerTest.cs
@@ -1,0 +1,144 @@
+﻿/*
+    Copyright (C) 2014 Omega software d.o.o.
+
+    This file is part of Rhetos.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using CommonConcepts.Test.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Rhetos;
+using Rhetos.Dom.DefaultConcepts;
+using Rhetos.Utilities;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CommonConcepts.Test
+{
+    [TestClass]
+    public class RhetosTransactionScopeContainerTest
+    {
+        [TestMethod]
+        public void ExplicitCommit()
+        {
+            var id1 = Guid.NewGuid();
+
+            using (var container = RhetosProcessHelper.Container.CreateTransactionScope())
+            {
+                var context = container.Resolve<Common.ExecutionContext>();
+                context.Repository.TestEntity.BaseEntity.Insert(new TestEntity.BaseEntity { ID = id1 });
+                container.CommitChanges();
+            }
+
+            using (var container = RhetosProcessHelper.Container.CreateTransactionScope())
+            {
+                var context = container.Resolve<Common.ExecutionContext>();
+                Assert.IsTrue(context.Repository.TestEntity.BaseEntity.Query(new[] { id1 }).Any());
+            }
+        }
+
+        [TestMethod]
+        public void RollbackByDefault()
+        {
+            var id1 = Guid.NewGuid();
+
+            try
+            {
+                using (var container = RhetosProcessHelper.Container.CreateTransactionScope())
+                {
+                    var context = container.Resolve<Common.ExecutionContext>();
+                    context.Repository.TestEntity.BaseEntity.Insert(new TestEntity.BaseEntity { ID = id1 });
+                    throw new FrameworkException(nameof(RollbackByDefault)); // The exception is not handled within transaction scope.
+#pragma warning disable CS0162 // Unreachable code detected
+                    container.CommitChanges();
+#pragma warning restore CS0162 // Unreachable code detected
+                }
+            }
+            catch (FrameworkException ex)
+            {
+                Console.WriteLine($"{ex.GetType().Name}: {ex.Message}");
+            }
+
+            using (var container = RhetosProcessHelper.Container.CreateTransactionScope())
+            {
+                var context = container.Resolve<Common.ExecutionContext>();
+                Assert.IsFalse(context.Repository.TestEntity.BaseEntity.Query(new[] { id1 }).Any());
+            }
+        }
+
+        /// <summary>
+        /// This is not an intended usage of RhetosTransactionScopeContainer because an unhandled exception will
+        /// incorrectly commit the transaction, but currently the framework allows it.
+        /// </summary>
+        [TestMethod]
+        public void EarlyCommit()
+        {
+            var id1 = Guid.NewGuid();
+
+            try
+            {
+                using (var container = RhetosProcessHelper.Container.CreateTransactionScope())
+                {
+                    container.CommitChanges(); // CommitChanges is incorrectly places at this position.
+                    var context = container.Resolve<Common.ExecutionContext>();
+                    context.Repository.TestEntity.BaseEntity.Insert(new TestEntity.BaseEntity { ID = id1 });
+                    throw new FrameworkException(nameof(EarlyCommit)); // The exception is not handled within transaction scope to discard the transaction.
+                }
+            }
+            catch (FrameworkException ex)
+            {
+                Console.WriteLine($"{ex.GetType().Name}: {ex.Message}");
+            }
+
+            using (var container = RhetosProcessHelper.Container.CreateTransactionScope())
+            {
+                var context = container.Resolve<Common.ExecutionContext>();
+                Assert.IsTrue(context.Repository.TestEntity.BaseEntity.Query(new[] { id1 }).Any()); // The transaction is committed because of incorrect implementation pattern above.
+            }
+        }
+
+        [TestMethod]
+        public void IndependentTransactions()
+        {
+            const int threadCount = 2;
+
+            int initialCount;
+            using (var container = RhetosProcessHelper.Container.CreateTransactionScope())
+            {
+                RhetosProcessHelper.CheckForParallelism(container.Resolve<ISqlExecuter>(), threadCount);
+                
+                var context = container.Resolve<Common.ExecutionContext>();
+                initialCount = context.Repository.TestEntity.BaseEntity.Query().Count();
+            }
+
+            var id1 = Guid.NewGuid();
+
+            Parallel.For(0, threadCount, thread =>
+            {
+                using (var container = RhetosProcessHelper.Container.CreateTransactionScope())
+                {
+                    var context = container.Resolve<Common.ExecutionContext>();
+
+                    Assert.AreEqual(initialCount, context.Repository.TestEntity.BaseEntity.Query().Count());
+                    Thread.Sleep(100);
+                    context.Repository.TestEntity.BaseEntity.Insert(new TestEntity.BaseEntity { ID = id1 }); // Each thread uses the same ID to make sure only one thread can run this code at same time.
+                    Assert.AreEqual(initialCount + 1, context.Repository.TestEntity.BaseEntity.Query().Count());
+                }
+            });
+        }
+    }
+}

--- a/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/RhetosTransactionScopeContainerTest.cs
+++ b/CommonConcepts/CommonConceptsTest/CommonConcepts.Test/RhetosTransactionScopeContainerTest.cs
@@ -62,7 +62,7 @@ namespace CommonConcepts.Test
                 {
                     var context = container.Resolve<Common.ExecutionContext>();
                     context.Repository.TestEntity.BaseEntity.Insert(new TestEntity.BaseEntity { ID = id1 });
-                    throw new FrameworkException(nameof(RollbackByDefault)); // The exception is not handled within transaction scope.
+                    throw new FrameworkException(nameof(RollbackByDefault)); // The exception that is not handled within transaction scope.
 #pragma warning disable CS0162 // Unreachable code detected
                     container.CommitChanges();
 #pragma warning restore CS0162 // Unreachable code detected
@@ -120,7 +120,7 @@ namespace CommonConcepts.Test
             using (var container = RhetosProcessHelper.Container.CreateTransactionScope())
             {
                 RhetosProcessHelper.CheckForParallelism(container.Resolve<ISqlExecuter>(), threadCount);
-                
+
                 var context = container.Resolve<Common.ExecutionContext>();
                 initialCount = context.Repository.TestEntity.BaseEntity.Query().Count();
             }

--- a/Source/DeployPackages/Program.cs
+++ b/Source/DeployPackages/Program.cs
@@ -218,7 +218,7 @@ namespace DeployPackages
             var deployment = new ApplicationDeployment(configuration, logProvider, LegacyUtilities.GetRuntimeAssembliesDelegate(configuration));
             deployment.UpdateDatabase();
             deployment.InitializeGeneratedApplication(host.RhetosRuntime);
-            deployment.RestartWebServer();
+            deployment.RestartWebServer(host.ConfigurationFolder);
         }
 
         private static void InteractiveExceptionInfo(Exception e, bool pauseOnError)

--- a/Source/MsBuildIntegration/Add-RhetosWcfFiles.ps1
+++ b/Source/MsBuildIntegration/Add-RhetosWcfFiles.ps1
@@ -6,8 +6,8 @@
 $sourceFolder = "$PSScriptRoot\projectFiles"
 $project = (Get-Project)
 $projectFolder = (Get-Item $project.FullName).DirectoryName
-"Target project: $project"
 "Source folder: $sourceFolder"
+"Target project: $($project.Name)"
 
 Copy-Item -Path "$sourceFolder\Web.config" -Destination $projectFolder -Force
 Copy-Item -Path "$sourceFolder\Rhetos Server DOM.linq" -Destination $projectFolder -Force

--- a/Source/Rhetos.Configuration.Autofac/ApplicationBuild.cs
+++ b/Source/Rhetos.Configuration.Autofac/ApplicationBuild.cs
@@ -98,7 +98,9 @@ namespace Rhetos
             builder.RegisterModule(new BuildModule());
             builder.AddPluginModules();
             builder.RegisterType<NullUserInfo>().As<IUserInfo>(); // Override runtime IUserInfo plugins. This container should not execute the application's business features.
+#pragma warning disable CS0618 // Registering obsolete IInstalledPackages for backward compatibility.
             builder.RegisterInstance(installedPackages).As<IInstalledPackages>().As<InstalledPackages>();
+#pragma warning restore CS0618
             return builder;
         }
     }

--- a/Source/Rhetos.Configuration.Autofac/ApplicationDeployment.cs
+++ b/Source/Rhetos.Configuration.Autofac/ApplicationDeployment.cs
@@ -114,9 +114,9 @@ namespace Rhetos
 
         //=====================================================================
 
-        public void RestartWebServer()
+        public void RestartWebServer(string configurationFolder)
         {
-            var configFile = Path.Combine(Paths.RhetosServerRootPath, "Web.config");
+            var configFile = Path.Combine(configurationFolder, "Web.config");
             if (FilesUtility.SafeTouch(configFile))
                 _logger.Info($"Updated {Path.GetFileName(configFile)} modification date to restart server.");
             else

--- a/Source/Rhetos.Configuration.Autofac/Modules/RuntimeModule.cs
+++ b/Source/Rhetos.Configuration.Autofac/Modules/RuntimeModule.cs
@@ -37,7 +37,9 @@ namespace Rhetos.Configuration.Autofac.Modules
             builder.Register(context => context.Resolve<IConfiguration>().GetOptions<RhetosAppEnvironment>()).SingleInstance();
             builder.RegisterType<InstalledPackagesProvider>();
             builder.Register(context => context.Resolve<InstalledPackagesProvider>().Load())
+#pragma warning disable CS0618 // Registering obsolete IInstalledPackages for backward compatibility.
                 .As<InstalledPackages>().As<IInstalledPackages>().SingleInstance();
+#pragma warning restore CS0618
             builder.Register(context => context.Resolve<IConfiguration>().GetOptions<RhetosAppOptions>())
                 .As<RhetosAppOptions>().As<IAssetsOptions>().SingleInstance();
             builder.RegisterType<DomLoader>().As<IDomainObjectModel>().SingleInstance();

--- a/Source/Rhetos.Configuration.Autofac/RhetosProcessContainer.cs
+++ b/Source/Rhetos.Configuration.Autofac/RhetosProcessContainer.cs
@@ -89,12 +89,13 @@ namespace Rhetos.Configuration.Autofac
 
         public T Resolve<T>() => _rhetosIocContainer.Value.Resolve<T>();
 
-        /// <param name="commitChanges">
-        /// Whether database updates (by ORM repositories) will be committed or rollbacked. By default it is set to true.
-        /// </param>
         /// <param name="registerCustomComponents">
-        /// Used to customize the transaction scope Dependency Injection container. By default it is set to null.
-        /// </param>/// 
-        public RhetosTransactionScopeContainer CreateTransactionScope(bool commitChanges, Action<ContainerBuilder> registerCustomComponents = null) => new RhetosTransactionScopeContainer(_rhetosIocContainer, commitChanges, registerCustomComponents);
+        /// Register custom components that may override system and plugins services.
+        /// This is commonly used by utilities and tests that need to override host application's components or register additional plugins.
+        /// </param>
+        public RhetosTransactionScopeContainer CreateTransactionScope(Action<ContainerBuilder> registerCustomComponents = null)
+        {
+            return new RhetosTransactionScopeContainer(_rhetosIocContainer, registerCustomComponents);
+        }
     }
 }

--- a/Source/Rhetos.Configuration.Autofac/RhetosTestContainer.cs
+++ b/Source/Rhetos.Configuration.Autofac/RhetosTestContainer.cs
@@ -112,7 +112,9 @@ namespace Rhetos.Configuration.Autofac
                         }
                 }
 
-                _rhetosTransactionScope = _rhetosProcessContainer.CreateTransactionScope(_commitChanges, InitializeSession);
+                _rhetosTransactionScope = _rhetosProcessContainer.CreateTransactionScope(InitializeSession);
+                if (_commitChanges)
+                    _rhetosTransactionScope.CommitChanges();
             }
         }
 

--- a/Source/Rhetos.Configuration.Autofac/RhetosTestContainer.cs
+++ b/Source/Rhetos.Configuration.Autofac/RhetosTestContainer.cs
@@ -18,7 +18,6 @@
 */
 
 using Autofac;
-using Rhetos.Extensibility;
 using Rhetos.Utilities;
 using System;
 using System.IO;
@@ -51,9 +50,8 @@ namespace Rhetos.Configuration.Autofac
         /// </param>
         public RhetosTestContainer(bool commitChanges = false, string rhetosServerFolder = null)
         {
-            if (rhetosServerFolder != null)
-                if (!Directory.Exists(rhetosServerFolder))
-                    throw new ArgumentException("The given folder does not exist: " + Path.GetFullPath(rhetosServerFolder) + ".");
+            if (rhetosServerFolder != null && !Directory.Exists(rhetosServerFolder))
+                throw new ArgumentException("The given folder does not exist: " + Path.GetFullPath(rhetosServerFolder) + ".");
 
             _commitChanges = commitChanges;
             _explicitRhetosServerFolder = rhetosServerFolder;
@@ -105,9 +103,8 @@ namespace Rhetos.Configuration.Autofac
                     lock (_containerInitializationLock)
                         if (_rhetosProcessContainer == null)
                         {
-                            _rhetosProcessContainer = new RhetosProcessContainer(SearchForRhetosServerRootFolder, new ConsoleLogProvider(),
+                            _rhetosProcessContainer = new RhetosProcessContainer(SearchForRhetosServerRootFolder(), new ConsoleLogProvider(),
                                 configurationBuilder => configurationBuilder.AddConfigurationManagerConfiguration());
-                            AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolver.GetResolveEventHandler(_rhetosProcessContainer.Configuration, new ConsoleLogProvider());
                         }
                 }
 

--- a/Source/Rhetos.Configuration.Autofac/RhetosTransactionScopeContainer.cs
+++ b/Source/Rhetos.Configuration.Autofac/RhetosTransactionScopeContainer.cs
@@ -43,9 +43,9 @@ namespace Rhetos.Configuration.Autofac
         /// Register custom components that may override system and plugins services.
         /// This is commonly used by utilities and tests that need to override host application's components or register additional plugins.
         /// </param>
-        public RhetosTransactionScopeContainer(Lazy<IContainer> iocContainer, Action<ContainerBuilder> registerCustomComponents = null)
+        public RhetosTransactionScopeContainer(IContainer iocContainer, Action<ContainerBuilder> registerCustomComponents = null)
         {
-            _lifetimeScope = new Lazy<ILifetimeScope>(() => registerCustomComponents != null ? iocContainer.Value.BeginLifetimeScope(registerCustomComponents) : iocContainer.Value.BeginLifetimeScope());
+            _lifetimeScope = new Lazy<ILifetimeScope>(() => registerCustomComponents != null ? iocContainer.BeginLifetimeScope(registerCustomComponents) : iocContainer.BeginLifetimeScope());
         }
 
         public T Resolve<T>()

--- a/Source/Rhetos.Extensibility/AssemblyResolver.cs
+++ b/Source/Rhetos.Extensibility/AssemblyResolver.cs
@@ -1,0 +1,86 @@
+﻿/*
+    Copyright (C) 2014 Omega software d.o.o.
+
+    This file is part of Rhetos.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using Rhetos.Logging;
+using Rhetos.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace Rhetos.Extensibility
+{
+    public static class AssemblyResolver
+    {
+        public static ResolveEventHandler GetResolveEventHandler(IConfiguration configuration, ILogProvider logProvider)
+        {
+            var rhetosAppOptins = configuration.GetOptions<RhetosAppOptions>();
+            var legacyPaths = configuration.GetOptions<LegacyPathsOptions>();
+
+            var searchFolders = new List<string>();
+            searchFolders.Add(rhetosAppOptins.GetAssemblyFolder());
+
+            if (!string.IsNullOrEmpty(legacyPaths.PluginsFolder))
+            {
+                searchFolders.Add(legacyPaths.PluginsFolder); // DeployPackages copies plugins from packages to Plugins folder.
+                searchFolders.Add(rhetosAppOptins.AssetsFolder); // DeployPackages generates runtime libraries in AssetsFolder.
+            }
+
+            var assemblies = searchFolders
+                .SelectMany(folder => Directory.GetFiles(folder, "*.dll", SearchOption.TopDirectoryOnly))
+                .Distinct()
+                .ToList();
+
+            return GetResolveEventHandler(assemblies, logProvider);
+        }
+
+        public static ResolveEventHandler GetResolveEventHandler(IEnumerable<string> assemblies, ILogProvider logProvider)
+        {
+            var logger = logProvider.GetLogger(nameof(AssemblyResolver));
+
+            var byFilename = assemblies
+                .GroupBy(Path.GetFileName)
+                .Select(group => new { filename = group.Key, paths = group.OrderBy(path => path.Length).ThenBy(path => path).ToList() })
+                .ToList();
+
+            foreach (var duplicate in byFilename.Where(dll => dll.paths.Count > 1))
+            {
+                var otherPaths = string.Join(", ", duplicate.paths.Skip(1).Select(path => $"'{path}'"));
+                logger.Warning($"Multiple paths for '{duplicate.filename}' found. This causes ambiguous DLL loading and can cause type errors. Loaded: '{duplicate.paths.First()}', ignored: {otherPaths}.");
+            }
+
+            var namesToPaths = byFilename.ToDictionary(dll => dll.filename, dll => dll.paths.First(), StringComparer.InvariantCultureIgnoreCase);
+
+            return (sender, args) => LoadAssemblyFromSpecifiedPaths(args, namesToPaths, logger);
+        }
+
+        private static Assembly LoadAssemblyFromSpecifiedPaths(ResolveEventArgs args, Dictionary<string, string> namesToPaths, ILogger logger)
+        {
+            var filename = $"{new AssemblyName(args.Name).Name}.dll";
+            if (namesToPaths.TryGetValue(filename, out var path))
+            {
+                logger.Trace(() => $"Custom resolver found assembly '{args.Name}' at '{path}'.");
+                return Assembly.LoadFrom(path);
+            }
+
+            return null;
+        }
+    }
+}

--- a/Source/Rhetos.Extensibility/PluginScanner.cs
+++ b/Source/Rhetos.Extensibility/PluginScanner.cs
@@ -142,11 +142,7 @@ namespace Rhetos.Extensibility
         {
             var stopwatch = Stopwatch.StartNew();
 
-            var assemblies = findAssemblies()
-                .Select(path => (Path: path, Name: Path.GetFileName(path)))
-                .Where(file => !_ignoreAssemblyFiles.Contains(file.Name) && !_ignoreAssemblyPrefixes.Any(prefix => file.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
-                .Select(file => Path.GetFullPath(file.Path))
-                .Distinct().ToList();
+            var assemblies = findAssemblies().Select(path => Path.GetFullPath(path)).Distinct().ToList();
 
             foreach (var assembly in assemblies)
                 if (!File.Exists(assembly))
@@ -161,6 +157,15 @@ namespace Rhetos.Extensibility
         private MultiDictionary<string, PluginInfo> LoadPlugins(List<string> assemblyPaths)
         {
             var stopwatch = Stopwatch.StartNew();
+
+            assemblyPaths = assemblyPaths
+                .Where(file =>
+                {
+                    string fileName = Path.GetFileName(file);
+                    return !_ignoreAssemblyFiles.Contains(fileName)
+                        && !_ignoreAssemblyPrefixes.Any(prefix => fileName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+                })
+                .ToList();
 
             lock (_pluginsCacheLock) // Reading and updating cache files should not be done in parallel.
             {

--- a/Source/Rhetos.Utilities.Test/LegacyUtilitiesTests.cs
+++ b/Source/Rhetos.Utilities.Test/LegacyUtilitiesTests.cs
@@ -26,6 +26,8 @@ namespace Rhetos.Utilities.Test
     [TestClass]
     public class LegacyUtilitiesTests
     {
+#pragma warning disable CS0618 // Type or member is obsolete
+
         [TestMethod]
         public void SqlUtilityWorksCorrectly()
         {
@@ -76,5 +78,7 @@ namespace Rhetos.Utilities.Test
             TestUtility.ShouldFail<FrameworkException>(() => Console.WriteLine(Paths.GeneratedFolder),
                 "Paths property 'GeneratedFolder' is not configured in 'build' environment.");
         }
+
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/Source/Rhetos.Utilities/ApplicationConfiguration/IRhetosRuntime.cs
+++ b/Source/Rhetos.Utilities/ApplicationConfiguration/IRhetosRuntime.cs
@@ -50,5 +50,10 @@ namespace Rhetos
         /// This is commonly used by utilities and tests that need to override host application's components or register additional plugins.
         /// </param>
         IContainer BuildContainer(ILogProvider logProvider, IConfiguration configuration, Action<ContainerBuilder> registerCustomComponents);
+
+        /// <summary>
+        /// Returns paths of application's runtime assemblies. It is required for plugin discovery and assembly resolver in external applications such as CLI utilities and tests.
+        /// </summary>
+        string[] GetRuntimeAssemblies(ILogProvider logProvider, IConfiguration configuration);
     }
 }

--- a/Source/Rhetos.Utilities/Legacy/LegacyUtilities.cs
+++ b/Source/Rhetos.Utilities/Legacy/LegacyUtilities.cs
@@ -18,64 +18,23 @@
 */
 
 using Rhetos.Utilities;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 
 namespace Rhetos
 {
     public static class LegacyUtilities
     {
-#pragma warning disable CS0618 // Type or member is obsolete
         /// <summary>
         /// Use to initialize obsolete static utilities <see cref="Paths"/>, <see cref="ConfigUtility"/>, <see cref="Configuration"/> and <see cref="SqlUtility"/> 
         /// prior to using any of their methods. This will bind those utilities to configuration source compliant with new configuration convention.
         /// </summary>
         public static void Initialize(IConfiguration configuration)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             Paths.Initialize(configuration);
             ConfigUtility.Initialize(configuration);
             SqlUtility.Initialize(configuration);
             Configuration.Initialize(configuration);
-        }
-
-        /// <summary>
-        /// Returns list of assemblies that will be scanned for plugin exports.
-        /// </summary>
-        public static Func<string[]> GetRuntimeAssembliesDelegate(IConfiguration configuration)
-        {
-            var runtimeOptions = configuration.GetOptions<RhetosAppOptions>();
-            var legacyPaths = configuration.GetOptions<LegacyPathsOptions>();
-
-            return () =>
-            {
-                var pluginsPaths = new List<string>();
-
-                if (!string.IsNullOrEmpty(legacyPaths.PluginsFolder))
-                {
-                    // Old build process (DeployPackages) copies plugins from packages to Plugins folder,
-                    // and builds new libraries in AssetsFolder.
-                    // We don't need to scan main AssemblyFolder because it contains only Rhetos framework binaries
-                    // that have no plugins exports, only explicit registrations.
-                    pluginsPaths.Add(legacyPaths.PluginsFolder);
-                    pluginsPaths.Add(runtimeOptions.AssetsFolder);
-                }
-                else
-                {
-                    pluginsPaths.Add(runtimeOptions.GetAssemblyFolder());
-                }
-
-                var assemblyFiles = pluginsPaths
-                    .Where(folder => Directory.Exists(folder)) // Some paths don't exist in certain phases of build and deployment.
-                    .SelectMany(folder => Directory.GetFiles(folder, "*.dll", SearchOption.TopDirectoryOnly))
-                    .Distinct()
-                    .OrderBy(file => file)
-                    .ToArray();
-
-                return assemblyFiles;
-            };
-        }
 #pragma warning restore CS0618 // Type or member is obsolete
+        }
     }
 }

--- a/Source/Rhetos/Rhetos Server DOM.linq
+++ b/Source/Rhetos/Rhetos Server DOM.linq
@@ -54,11 +54,10 @@
 
 void Main()
 {
-    ConsoleLogger.MinLevel = EventType.Info; // Use "Trace" for more detailed log.
-    var rhetosServerPath = Path.GetDirectoryName(Util.CurrentQueryPath);
-    Directory.SetCurrentDirectory(rhetosServerPath);
-    // Set commitChanges parameter to COMMIT or ROLLBACK the data changes.
-    using (var container = new RhetosTestContainer(commitChanges: false))
+	string applicationFolder = Path.GetDirectoryName(Util.CurrentQueryPath);
+	ConsoleLogger.MinLevel = EventType.Info; // Use EventType.Trace for more detailed log.
+	
+	using (var container = RhetosProcessContainer.CreateTransactionScope(applicationFolder))
     {
         var context = container.Resolve<Common.ExecutionContext>();
         var repository = context.Repository;
@@ -86,5 +85,7 @@ void Main()
             .Dump("Common.Principal log");
             
         Console.WriteLine("Done.");
+		
+		//container.CommitChanges(); // Database transaction is rolled back by default.
     }
 }

--- a/Source/RhetosCli/Program.cs
+++ b/Source/RhetosCli/Program.cs
@@ -25,8 +25,6 @@ using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
-using System.Linq;
-using System.Reflection;
 
 namespace Rhetos
 {
@@ -155,7 +153,7 @@ namespace Rhetos
                     configurationBuilder.AddKeyValue($"{OptionsAttribute.GetConfigurationPath<DbUpdateOptions>()}:{nameof(DbUpdateOptions.SkipRecompute)}", skipRecompute);
             });
 
-            var assemblyFiles = LegacyUtilities.GetRuntimeAssembliesDelegate(configuration).Invoke(); // Using same assembly locations as the generated application runtime.
+            var assemblyFiles = host.RhetosRuntime.GetRuntimeAssemblies(LogProvider, configuration);
             AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolver.GetResolveEventHandler(assemblyFiles, LogProvider);
 
             var deployment = new ApplicationDeployment(configuration, LogProvider, () => assemblyFiles);


### PR DESCRIPTION
Assembly resolver:

* Refactoring 3 assembly resolvers into a single class.
* Added IRhetosRuntime.GetRuntimeAssemblies for Rhetos plugin discovery and assembly resolver in external utilities and tests. RhetosProcessContainer registers AssemblyResolver for the runtime assemblies.

RhetosProcessContainer:

* Using static RhetosProcessContainer instead of RhetosTestContainer for LINQPad script.
Implemented static RhetosProcessContainer as a helper for *optimization* of LINQPad scripts: When recompiling the script, LINQPad will reuse the static instance of RhetosProcessContainer because it is owned by a referenced assembly, not by the script.
* RhetosTransactionScopeContainer now expects explicit *commit* confirmation at the and of the unit of work. This will result with better error handling: an unhandled exception will roll back the transaction by default.