### PR TITLE
Fixed inconsistent database schema owners (with ALTER)

### DIFF
--- a/CommonConcepts/DataMigration/4.3/1  - Set schema authorization to dbo.sql
+++ b/CommonConcepts/DataMigration/4.3/1  - Set schema authorization to dbo.sql
@@ -1,0 +1,30 @@
+/*DATAMIGRATION 191DE223-880F-40E8-9D14-75883886B6E1*/ -- Change the script's code only if it needs to be executed again.
+
+SELECT
+    SchemaName = SUBSTRING(ConceptInfoKey, 12, 256)
+INTO
+    #RhetosSchemas
+FROM
+    Rhetos.AppliedConcept
+WHERE
+    CreateQuery LIKE 'CREATE SCHEMA %'
+    AND ConceptInfoKey LIKE 'ModuleInfo %';
+
+DECLARE @sql nvarchar(max) = '';
+
+SELECT
+    @sql = @sql + 'ALTER AUTHORIZATION ON SCHEMA::[' + name + '] TO dbo;
+'
+FROM
+    sys.schemas
+WHERE
+    (
+        name IN (SELECT SchemaName FROM #RhetosSchemas)
+        OR name IN (SELECT '_' + SchemaName FROM #RhetosSchemas)
+    )
+    AND principal_id <> USER_ID('dbo');
+
+PRINT @sql;
+EXEC sp_executesql @sql;
+
+DROP TABLE #RhetosSchemas;

--- a/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DataStructure/ModuleAuthorizationMacro.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dsl.DefaultConcepts/DataStructure/ModuleAuthorizationMacro.cs
@@ -1,0 +1,50 @@
+﻿/*
+    Copyright (C) 2014 Omega software d.o.o.
+
+    This file is part of Rhetos.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+
+namespace Rhetos.Dsl.DefaultConcepts
+{
+    /// <summary>
+    /// NOTE:
+    /// This class applies 'dbo' authorization to database schema by creating a separate ALTER AUTHORIZATION query,
+    /// instead of adding the AUTHORIZATION option to the CREATE SCHEMA query, in order to avoid dropping
+    /// and recreating all database objects on deployment when upgrading existing applications.
+    /// The upgrade could be handled efficiently by a data-migration script that alters the scheme authorization
+    /// and Rhetos.AppliedConcepts, but it wouldn't support optimized downgrade to a previous version of CommonConcepts package.
+    /// </summary>
+    [Export(typeof(IConceptMacro))]
+    public class ModuleAuthorizationMacro : IConceptMacro<ModuleInfo>
+    {
+        public IEnumerable<IConceptInfo> CreateNewConcepts(ModuleInfo conceptInfo, IDslModel existingConcepts)
+        {
+            return new[]
+            {
+                new SqlObjectInfo
+                {
+                    Module = conceptInfo,
+                    Name = "SchemaAuthorization",
+                    CreateSql = $"ALTER AUTHORIZATION ON SCHEMA::{conceptInfo.Name} TO dbo",
+                    RemoveSql = ""
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
This closes #92.
This issue is solved by creating a separate ALTER AUTHORIZATION query, instead of adding the AUTHORIZATION option to the CREATE SCHEMA query, to avoid dropping and recreating all database objects on deployment. This could be handled efficiently by a data-migration script that alters the scheme authorization and Rhetos.AppliedConcepts, but it wouldn't support optimized downgrade.