### PR TITLE
Fixed BuildRhetosApp target when a file is deleted

### DIFF
--- a/Source/MsBuildIntegration/Rhetos.MSBuild.props
+++ b/Source/MsBuildIntegration/Rhetos.MSBuild.props
@@ -3,12 +3,14 @@
         <RhetosCliExecutablePath>$(MSBuildThisFileDirectory)..\tools\rhetos.exe</RhetosCliExecutablePath>
         <RhetosBuild Condition=" '$(RhetosBuild)'=='' ">True</RhetosBuild>
         <RhetosDeploy Condition=" '$(RhetosDeploy)'=='' ">True</RhetosDeploy>
+        <RhetosBuildItemsFile>$(BaseIntermediateOutputPath)Rhetos\Rhetos.BuildItems</RhetosBuildItemsFile>
         <RhetosBuildCompleteFile>$(BaseIntermediateOutputPath)Rhetos\Rhetos.BuildComplete</RhetosBuildCompleteFile>
         <RhetosDatabaseUpdated>$(BaseIntermediateOutputPath)Rhetos\Rhetos.DatabaseUpdated</RhetosDatabaseUpdated>
         <RhetosGeneratedAssetsFolder Condition=" '$(RhetosGeneratedAssetsFolder)'=='' ">$(TargetDir)RhetosAssets\</RhetosGeneratedAssetsFolder>
     </PropertyGroup>
     <ItemGroup>
         <RhetosInput Include="$(BaseIntermediateOutputPath)project.assets.json" />
+        <RhetosInput Include="$(RhetosBuildItemsFile)" />
         <RhetosInput Include="rhetos-build.settings.json" />
         <RhetosBuild Include="DslScripts\**\*" />
         <RhetosBuild Include="DataMigration\**\*" />        

--- a/Source/MsBuildIntegration/Rhetos.MSBuild.targets
+++ b/Source/MsBuildIntegration/Rhetos.MSBuild.targets
@@ -12,6 +12,7 @@
             IntermediateOutputFolder="$(BaseIntermediateOutputPath)Rhetos"
             TargetPath="$(TargetPath)"
             TargetAssetsFolder="$(TargetDir)RhetosAssets" />
+        <WriteLinesToFile Lines="@(RhetosBuild)" Overwrite="True" WriteOnlyWhenDifferent="True" File="$(RhetosBuildItemsFile)"/>
     </Target>
 
     <Target Name="BuildRhetosApp" DependsOnTargets="ResolveRhetosProjectAssets;" BeforeTargets="CoreCompile" Condition="'$(RhetosBuild)'=='True' and $(BuildingProject)=='True'" Inputs="@(RhetosInput);@(RhetosBuild);@(ReferencePath)" Outputs="@(RhetosOutput)">


### PR DESCRIPTION
When deleting a file that is an input for the BuildRhetosApp target, that target was not started because the Input property on the target does not take into consideration a deleted file. The RhetosBuild items are written as a list to the Rhetos.BuildItems file so when a file is deleted the Rhetos.BuildItems file will be changed and will trigger the BuildRhetosApp target.