### PR TITLE
Improvements in RhetosHost.FindBuilder so that it can be used with Li…

### DIFF
--- a/Source/Rhetos.Configuration.Autofac/RhetosHost.cs
+++ b/Source/Rhetos.Configuration.Autofac/RhetosHost.cs
@@ -92,7 +92,13 @@ namespace Rhetos
             if (!File.Exists(hostFilePath))
                 throw new ArgumentException($"Please specify the host application assembly file. File '{hostFilePath}' does not exist.");
 
-            var startupAssembly = Assembly.LoadFrom(hostFilePath);
+            //The Assembly.LoadFrom method will load the Assembly in the DefaultLoadContext.
+            //In most cases this will work but wen using Linqpad this can lead to unexpected behavuour when comparing types because
+            //linqpad will load the reference assemblies in another context.
+            //The Assembly.Load(AssemblyName) method will load the Assembly in the AssemblyLoadContext.CurrentContextualReflectionContext if it is set or AssemblyLoadContext.Default
+            //and we are using this behaviour because if needed the application developer can change the AssemblyLoadContext.CurrentContextualReflectionContext
+            //with AssemblyLoadContext.EnterContextualReflection
+            var startupAssembly = (AssemblyLoadContext.CurrentContextualReflectionContext ?? AssemblyLoadContext.Default).LoadFromAssemblyPath(hostFilePath);
             if (startupAssembly == null)
                 throw new FrameworkException($"Could not resolve assembly from path '{hostFilePath}'.");
 

--- a/Source/RhetosVSIntegration/ResolveRhetosProjectAssets.cs
+++ b/Source/RhetosVSIntegration/ResolveRhetosProjectAssets.cs
@@ -60,7 +60,7 @@ namespace RhetosVSIntegration
             if (invalidProjectContentFiles.Any())
                 throw new FrameworkException("Could not resolve the full path for the Rhetos input files " + string.Join(", ", invalidProjectContentFiles.Select(x => x.ItemSpec)).Limit(1000));
 
-            var assembliesInReferencedProjects = Assemblies.Where(x => !string.IsNullOrEmpty(x.GetMetadata("Project"))).Select(x => new { x.ItemSpec, FullPath = x.GetMetadata("FullPath") });
+            var assembliesInReferencedProjects = Assemblies.Where(x => !string.IsNullOrEmpty(x.GetMetadata("MSBuildSourceProjectFile"))).Select(x => new { x.ItemSpec, FullPath = x.GetMetadata("FullPath") });
             var invalidAssembliesInReferencedProjects = assembliesInReferencedProjects.Where(x => string.IsNullOrEmpty(x.FullPath));
             if (invalidAssembliesInReferencedProjects.Any())
                 throw new FrameworkException("Could not resolve the full path for the referenced assemblies " + string.Join(", ", invalidAssembliesInReferencedProjects.Select(x => x.ItemSpec)).Limit(1000));


### PR DESCRIPTION
…nqpad.

Fixed ResolveRhetosProjectAssets MSBuild task so that can recoginze assemblies from referenced project in the new SDK project style.