### PR TITLE
Rhetos host builder base

### DIFF
--- a/CommonConcepts/CommonConcepts.Test/Helpers/Program.cs
+++ b/CommonConcepts/CommonConcepts.Test/Helpers/Program.cs
@@ -22,6 +22,7 @@ using Rhetos;
 using Rhetos.Logging;
 using Rhetos.Security;
 using Rhetos.Utilities;
+using System;
 
 namespace CommonConcepts.Test
 {
@@ -29,6 +30,7 @@ namespace CommonConcepts.Test
     {
         public static void Main()
         {
+            Console.WriteLine("This is a placeholder application for unit testing. Its features are executed by unit tests.");
         }
 
         /// <summary>
@@ -37,6 +39,7 @@ namespace CommonConcepts.Test
         public static IRhetosHostBuilder CreateRhetosHostBuilder()
         {
             return new RhetosHostBuilder()
+                .ConfigureRhetosHostDefaults()
                 .ConfigureConfiguration(builder =>
                 {
                     builder.AddJsonFile(RhetosAppEnvironment.LocalConfigurationFileName);

--- a/CommonConcepts/CommonConcepts.Test/Helpers/TestScope.cs
+++ b/CommonConcepts/CommonConcepts.Test/Helpers/TestScope.cs
@@ -40,13 +40,13 @@ namespace CommonConcepts.Test
         /// </remarks>
         public static TransactionScopeContainer Create(Action<ContainerBuilder> registerCustomComponents = null)
         {
-            return RhetosHost.CreateScope(registerCustomComponents);
+            return _rhetosHost.CreateScope(registerCustomComponents);
         }
 
         /// <summary>
         /// Reusing a single shared static DI container between tests, to reduce initialization time for each test.
         /// Each test should create a child scope with <see cref="TestScope.Create"/> method to start a 'using' block.
         /// </summary>
-        private static readonly RhetosHost RhetosHost = Program.CreateRhetosHostBuilder().Build();
+        private static readonly RhetosHost _rhetosHost = Program.CreateRhetosHostBuilder().Build();
     }
 }

--- a/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/DataStructure/DomInitializationCodeGenerator.cs
+++ b/CommonConcepts/Plugins/Rhetos.Dom.DefaultConcepts/DataStructure/DomInitializationCodeGenerator.cs
@@ -84,8 +84,8 @@ namespace Rhetos.Dom.DefaultConcepts
 
         private string GetInitialConfigurationSnippet()
         {
-            return $@"
-            ConfigureConfiguration(builder => {{
+            return
+            $@"hostBuilder.ConfigureConfiguration(builder => {{
                 builder.AddOptions(new Rhetos.Dom.DefaultConcepts.CommonConceptsDatabaseSettings
                 {{
                     UseLegacyMsSqlDateTime = {_databaseSettings.UseLegacyMsSqlDateTime.ToString().ToLowerInvariant()},

--- a/Source/Rhetos.Configuration.Autofac.Test/AutofacConfigurationTest.cs
+++ b/Source/Rhetos.Configuration.Autofac.Test/AutofacConfigurationTest.cs
@@ -35,14 +35,11 @@ namespace Rhetos.Configuration.Autofac.Test
     [TestClass]
     public class AutofacConfigurationTest
     {
-        private class RhetosHostTestBuilder : RhetosHostBuilderBase
+        private class RhetosHostTestBuilder : RhetosHostBuilder
         {
-            protected override ContainerBuilder CreateContainerBuilder(IConfiguration configuration)
+            public RhetosHostTestBuilder()
             {
-                var pluginAssemblies = new[] { Assembly.GetExecutingAssembly() };
-                var pluginTypes = Array.Empty<Type>();
-                var pluginScanner = new RuntimePluginScanner(pluginAssemblies, pluginTypes, _builderLogProvider);
-                return new RhetosContainerBuilder(configuration, _builderLogProvider, pluginScanner);
+                AddPluginAssemblies(new[] { Assembly.GetExecutingAssembly() });
             }
         }
 

--- a/Source/Rhetos.Configuration.Autofac/IRhetosHostBuilder.cs
+++ b/Source/Rhetos.Configuration.Autofac/IRhetosHostBuilder.cs
@@ -22,6 +22,8 @@ using Rhetos.Logging;
 using Rhetos.Utilities;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Reflection;
 
 namespace Rhetos
 {
@@ -68,6 +70,22 @@ namespace Rhetos
         /// method directly from the custom application code.
         /// </remarks>
         IRhetosHostBuilder UseRootFolder(string rootFolder);
+
+        /// <summary>
+        /// The assemblies will be scanned for plugins while building the
+        /// dependency injection container.
+        /// Plugin is a class marked with <see cref="ExportAttribute"/>,
+        /// and optionally additional metadata in <see cref="ExportMetadataAttribute"/>.
+        /// </summary>
+        IRhetosHostBuilder AddPluginAssemblies(IEnumerable<Assembly> assemblies);
+
+        /// <summary>
+        /// The types will be scanned for plugins while building the
+        /// dependency injection container.
+        /// Plugin is a class marked with <see cref="ExportAttribute"/>,
+        /// and optionally additional metadata in <see cref="ExportMetadataAttribute"/>.
+        /// </summary>
+        IRhetosHostBuilder AddPluginTypes(IEnumerable<Type> types);
 
         /// <summary>
         /// Create the <see cref="RhetosHost"/> instance, that serves as a wrapper around Rhetos system configuration and 

--- a/Source/Rhetos.Dom/InitialDomCodeGenerator.cs
+++ b/Source/Rhetos.Dom/InitialDomCodeGenerator.cs
@@ -51,7 +51,8 @@ namespace Rhetos.Dom
                 addPlugins.Append($"typeof({plugin.Type.FullName}),{Environment.NewLine}                ");
             }
 
-            var rhetosHostBuilderCode = $@"using Autofac;
+            var rhetosHostBuilderCode =
+$@"using Autofac;
 using Rhetos.Utilities;
 using System;
 using System.Collections.Generic;
@@ -59,28 +60,21 @@ using System.Reflection;
 
 namespace Rhetos
 {{
-    public class RhetosHostBuilder : RhetosHostBuilderBase
+    public static class RhetosHostBuilderExtensions
     {{
-        public RhetosHostBuilder()
+        public static IRhetosHostBuilder ConfigureRhetosHostDefaults(this IRhetosHostBuilder hostBuilder)
         {{
-            InitializeConfiguration();
-        }}
-
-        protected override ContainerBuilder CreateContainerBuilder(IConfiguration configuration)
-        {{
-            var pluginScanner = new Rhetos.Extensibility.RuntimePluginScanner(GetPluginAssemblies(), GetPluginTypes(), _builderLogProvider);
-            return new RhetosContainerBuilder(configuration, _builderLogProvider, pluginScanner);
-        }}
-
-        private void InitializeConfiguration()
-        {{
-            ConfigureConfiguration(builder => {{
-                builder.AddOptions(new Rhetos.Utilities.DatabaseSettings
-                {{
-                    DatabaseLanguage = {CsUtility.QuotedString(_databaseSettings.DatabaseLanguage)},
-                }});
-            }});
+            hostBuilder
+                .ConfigureConfiguration(containerBuilder => {{
+                    containerBuilder.AddOptions(new Rhetos.Utilities.DatabaseSettings
+                    {{
+                        DatabaseLanguage = {CsUtility.QuotedString(_databaseSettings.DatabaseLanguage)},
+                    }});
+                }})
+                .AddPluginAssemblies(GetPluginAssemblies())
+                .AddPluginTypes(GetPluginTypes());
             {RhetosHostBuilderInitialConfigurationTag}
+            return hostBuilder;
         }}
 
         private static IEnumerable<Assembly> GetPluginAssemblies()
@@ -105,7 +99,7 @@ namespace Rhetos
 }}
 ";
 
-            codeBuilder.InsertCodeToFile(rhetosHostBuilderCode, "RhetosHostBuilder");
+            codeBuilder.InsertCodeToFile(rhetosHostBuilderCode, "RhetosHostBuilderExtensions");
         }
     }
 }

--- a/Source/Rhetos.Utilities/SqlUtility.cs
+++ b/Source/Rhetos.Utilities/SqlUtility.cs
@@ -22,7 +22,6 @@ using System;
 using System.Data.Common;
 using System.Data.SqlClient;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 
 namespace Rhetos.Utilities
@@ -33,7 +32,7 @@ namespace Rhetos.Utilities
         public static int SqlCommandTimeout { get; private set; } = 30;
         public static string DatabaseLanguage => CheckIfInitialized(_databaseLanguage, "database language");
         public static string NationalLanguage => CheckIfInitialized(_nationalLanguage, "national language");
-        public static string ConnectionString => CheckIfInitialized(_connectionString, $"connection string (name=\"{RhetosConnectionStringName}\")");
+        public static string ConnectionString => CheckIfInitialized(_connectionString, $"connection string '{RhetosConnectionStringName}' (settings key \"{ConnectionStringConfigurationKey}\")");
         public static string ProviderName => CheckIfInitialized(_providerName, "provider name");
 
         private static bool _initialized = false;
@@ -45,13 +44,14 @@ namespace Rhetos.Utilities
         private static string _providerName;
 
         private const string RhetosConnectionStringName = "ServerConnectionString";
+        private const string ConnectionStringConfigurationKey = "ConnectionStrings:" + RhetosConnectionStringName + ":ConnectionString";
 
         private static T CheckIfInitialized<T>(T value, string property)
         {
             if (!_initialized)
                 throw new FrameworkException("SqlUtility has not been initialized. Call LegacyUtilities.Initialize() at application startup.");
             else if (value == null)
-                throw new FrameworkException($"SqlUtility has not been initialized correctly: Value for {property} is not specified.");
+                throw new FrameworkException($"Configuration value for {property} is not specified.");
             return value;
         }
 
@@ -62,7 +62,8 @@ namespace Rhetos.Utilities
             var dbOptions = configuration.GetOptions<DatabaseOptions>();
             SqlCommandTimeout = dbOptions.SqlCommandTimeout;
 
-            _connectionString = configuration.GetValue<string>($"ConnectionStrings:{RhetosConnectionStringName}:ConnectionString");
+            
+            _connectionString = configuration.GetValue<string>(ConnectionStringConfigurationKey);
 
             var databaseSettings = configuration.GetOptions<DatabaseSettings>();
             _databaseLanguage = databaseSettings.DatabaseLanguage;


### PR DESCRIPTION
Renamed RhetosHostBuilder to RhetosHostBuilder and removed the inheritance. The generated initialization method is an extensions of IRhetosHostBuilder: ConfigureRhetosHostDefaults. This design is simpler because RhetosHostBuilder from framework is usable on its own (see diff in AutofacConfigurationTest.cs), and the generated initialization is just standard configuration.