### PR TITLE
Name of the connection string that Rhetos used is renamed to RhetosCo…

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -55,6 +55,27 @@
 23. Run-time configuration no longer depends on "rhetos-app.settings.json" file.
     * Rhetos:App:AssetsFolder and Rhetos:App:RhetosRuntimePath settings may be removed from this file.
     * The file may be deleted if empty.
+24. ServerConnectionString is renamed to RhetosConnectionString. When using config file change the name of the connection string to RhetosConnectionString. For json configurations change the configuration from
+
+    ```json
+    {
+        "ConnectionStrings": {
+            "ServerConnectionString":{
+                "ConnectionString": "Database connection string"
+            }
+        }
+    }
+    ```
+
+    to
+
+    ```json
+    {
+        "ConnectionStrings": {
+            "RhetosConnectionString": "Database connection string"
+        }
+    }
+    ```
 
 ## 4.3.0 (TO BE RELEASED)
 

--- a/Source/Rhetos.Configuration.Autofac.Test/AutofacConfigurationTest.cs
+++ b/Source/Rhetos.Configuration.Autofac.Test/AutofacConfigurationTest.cs
@@ -134,7 +134,7 @@ namespace Rhetos.Configuration.Autofac.Test
         {
             var configuration = GetBuildConfiguration();
             Assert.AreEqual("TestValue", configuration.GetValue<string>("TestBuildSettings"));
-            var connectionsString = configuration.GetValue<string>($"ConnectionStrings:ServerConnectionString:ConnectionString");
+            var connectionsString = configuration.GetValue<string>($"ConnectionStrings:RhetosConnectionString");
             TestUtility.AssertContains(connectionsString, new[] { "TestSql", "TestDb" });
         }
 

--- a/Source/Rhetos.Configuration.Autofac.Test/rhetos-app.settings.json
+++ b/Source/Rhetos.Configuration.Autofac.Test/rhetos-app.settings.json
@@ -1,7 +1,5 @@
 {
   "ConnectionStrings": {
-    "ServerConnectionString": {
-      "ConnectionString": "Data Source=TestSql;Initial Catalog=TestDb;Integrated Security=True"
-    }
+    "RhetosConnectionString": "Data Source=TestSql;Initial Catalog=TestDb;Integrated Security=True"
   }
 }

--- a/Source/Rhetos.Configuration.Autofac.Test/rhetos-build.settings.json
+++ b/Source/Rhetos.Configuration.Autofac.Test/rhetos-build.settings.json
@@ -1,8 +1,6 @@
 ﻿{
   "TestBuildSettings": "TestValue",
   "ConnectionStrings": {
-    "ServerConnectionString": {
-      "ConnectionString": "Data Source=TestSql;Initial Catalog=TestDb;Integrated Security=True"
-    }
+    "RhetosConnectionString": "Data Source=TestSql;Initial Catalog=TestDb;Integrated Security=True"
   }
 }

--- a/Source/Rhetos.Utilities.Test/ConfigurationProviderTests.cs
+++ b/Source/Rhetos.Utilities.Test/ConfigurationProviderTests.cs
@@ -290,7 +290,7 @@ namespace Rhetos.Utilities.Test
                 .AddConfigurationManagerConfiguration()
                 .Build();
 
-            Assert.IsTrue(provider.AllKeys.Contains("ConnectionStrings:ServerConnectionString:Name"));
+            Assert.IsTrue(provider.AllKeys.Contains("ConnectionStrings:RhetosConnectionString"));
             Assert.AreEqual(31, provider.GetValue("Rhetos:Database:SqlCommandTimeout", 0));
             Assert.AreEqual("TestSettingValue", provider.GetValue("AdditionalTestSetting", "", "TestSection"));
         }
@@ -302,8 +302,8 @@ namespace Rhetos.Utilities.Test
                 .AddConfigurationManagerConfiguration()
                 .Build();
 
-            var connectionStringName = provider.GetValue<string>($"ConnectionStrings:ServerConnectionString:Name");
-            Assert.AreEqual("ServerConnectionString", connectionStringName);
+            var connectionString = provider.GetValue<string>($"ConnectionStrings:RhetosConnectionString");
+            Assert.IsTrue(connectionString.Contains("Catalog=DummyDatabaseName;"));
         }
 
 
@@ -314,7 +314,7 @@ namespace Rhetos.Utilities.Test
                 .AddConfigurationFile("TestCfg.config")
                 .Build();
 
-            Assert.IsTrue(provider.AllKeys.Contains("ConnectionStrings:TestConnectionString:Name"));
+            Assert.IsTrue(provider.AllKeys.Contains("ConnectionStrings:TestConnectionString"));
             Assert.AreEqual(99, provider.GetValue("TestCfgValue", 0));
         }
 

--- a/Source/Rhetos.Utilities.Test/ConnectionStrings.config
+++ b/Source/Rhetos.Utilities.Test/ConnectionStrings.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <connectionStrings>
-  <add connectionString="Data Source=DummyServerName;Initial Catalog=DummyDatabaseName;Integrated Security=true;" name="ServerConnectionString" />
+  <add connectionString="Data Source=DummyServerName;Initial Catalog=DummyDatabaseName;Integrated Security=true;" name="RhetosConnectionString" />
 </connectionStrings>

--- a/Source/Rhetos.Utilities/ApplicationConfiguration/ConfigurationSources/DotNetConfigurationSource.cs
+++ b/Source/Rhetos.Utilities/ApplicationConfiguration/ConfigurationSources/DotNetConfigurationSource.cs
@@ -47,9 +47,7 @@ namespace Rhetos.Utilities.ApplicationConfiguration.ConfigurationSources
                 foreach (ConnectionStringSettings connectionString in connectionStrings)
                 {
                     var connectionSectionName = $"ConnectionStrings{ConfigurationProvider.ConfigurationPathSeparator}{connectionString.Name}";
-                    settings[$"{connectionSectionName}{ConfigurationProvider.ConfigurationPathSeparator}Name"] = new ConfigurationValue(connectionString.Name, this);
-                    settings[$"{connectionSectionName}{ConfigurationProvider.ConfigurationPathSeparator}ConnectionString"] = new ConfigurationValue(connectionString.ConnectionString, this);
-                    settings[$"{connectionSectionName}{ConfigurationProvider.ConfigurationPathSeparator}ProviderName"] = new ConfigurationValue(connectionString.ProviderName, this);
+                    settings[connectionSectionName] = new ConfigurationValue(connectionString.ConnectionString, this);
                 }
 
             return settings;

--- a/Source/Rhetos.Utilities/SqlUtility.cs
+++ b/Source/Rhetos.Utilities/SqlUtility.cs
@@ -43,8 +43,8 @@ namespace Rhetos.Utilities
         private static string _connectionString;
         private static string _providerName;
 
-        private const string RhetosConnectionStringName = "ServerConnectionString";
-        private const string ConnectionStringConfigurationKey = "ConnectionStrings:" + RhetosConnectionStringName + ":ConnectionString";
+        private const string RhetosConnectionStringName = "RhetosConnectionString";
+        private const string ConnectionStringConfigurationKey = "ConnectionStrings:" + RhetosConnectionStringName;
 
         private static T CheckIfInitialized<T>(T value, string property)
         {

--- a/Tools/Configuration/Template.rhetos-app.local.settings.json
+++ b/Tools/Configuration/Template.rhetos-app.local.settings.json
@@ -1,7 +1,5 @@
 {
-    "ConnectionStrings": {
-      "ServerConnectionString": {
-        "ConnectionString": "Data Source=ENTER_SQL_SERVER_NAME;Initial Catalog=ENTER_RHETOS_DATABASE_NAME;Integrated Security=true;"
-      }
-    }
+  "ConnectionStrings": {
+    "RhetosConnectionString": "Data Source=ENTER_SQL_SERVER_NAME;Initial Catalog=ENTER_RHETOS_DATABASE_NAME;Integrated Security=true;"
+  }
 }


### PR DESCRIPTION
…nnectionString.

ConnectionStrings:RhetosConnectionString is now a string instead of an object.