### PR TITLE
Convert path separators when loading JSON files

### DIFF
--- a/Source/Rhetos.Deployment.Interfaces/InstalledPackage.cs
+++ b/Source/Rhetos.Deployment.Interfaces/InstalledPackage.cs
@@ -1,4 +1,5 @@
-﻿/*
+﻿using System.IO;
+/*
     Copyright (C) 2014 Omega software d.o.o.
 
     This file is part of Rhetos.
@@ -73,6 +74,18 @@ namespace Rhetos.Deployment
             Folder = null;
             foreach (var file in ContentFiles)
                 file.PhysicalPath = null;
+        }
+
+        /// <summary>
+        /// Replace "/" or "\" in package paths to Path.DirectorySeparatorChar, to locate correctly package
+        /// location in cross-platform environment. 
+        /// </summary>
+        public void ConvertToCrossPlatformPaths() 
+        {
+            foreach (var file in ContentFiles)
+                file.InPackagePath = file.InPackagePath
+                    .Replace('/', Path.DirectorySeparatorChar)
+                    .Replace('\\', Path.DirectorySeparatorChar);
         }
     }
 }

--- a/Source/Rhetos.Deployment/DataMigrationScripts.cs
+++ b/Source/Rhetos.Deployment/DataMigrationScripts.cs
@@ -18,6 +18,7 @@
 */
 
 using System.Collections.Generic;
+using System.IO;
 
 namespace Rhetos.Deployment
 {
@@ -27,5 +28,17 @@ namespace Rhetos.Deployment
         /// The scripts are sorted by the intended execution order.
         /// </summary>
         public List<DataMigrationScript> Scripts { get; set; }
+
+        /// <summary>
+        /// Replace "/" or "\" in script paths to Path.DirectorySeparatorChar, to locate correctly script 
+        /// location in cross-platform environment. 
+        /// </summary>
+        public void ConvertToCrossPlatformPaths() 
+        {
+            foreach (var file in Scripts)
+                file.Path = file.Path
+                    .Replace('/', Path.DirectorySeparatorChar)
+                    .Replace('\\', Path.DirectorySeparatorChar);
+        }
     }
 }

--- a/Source/Rhetos.Deployment/DataMigrationScriptsFile.cs
+++ b/Source/Rhetos.Deployment/DataMigrationScriptsFile.cs
@@ -45,10 +45,16 @@ namespace Rhetos.Deployment
         public DataMigrationScripts Load()
         {
             var stopwatch = Stopwatch.StartNew();
+
             if (!File.Exists(_dataMigrationScriptsFilePath))
                 throw new FrameworkException($@"The file '{_dataMigrationScriptsFilePath}' with data-migration scripts is missing. Please check that the build has completed successfully before updating the database.");
+
             var dataMigrationScripts = JsonUtility.DeserializeFromFile<DataMigrationScripts>(_dataMigrationScriptsFilePath);
+
+            dataMigrationScripts.ConvertToCrossPlatformPaths();
+
             _performanceLogger.Write(stopwatch, $"Loaded {dataMigrationScripts.Scripts.Count} scripts from generated file.");
+
             return dataMigrationScripts;
         }
 

--- a/Source/Rhetos.Deployment/InstalledPackagesProvider.cs
+++ b/Source/Rhetos.Deployment/InstalledPackagesProvider.cs
@@ -44,10 +44,13 @@ namespace Rhetos.Deployment
             foreach (var package in installedPackages.Packages)
                 _logger.Trace(() => package.Report());
 
-            // Removing the folder path because it is a build feature and any plugin that is trying to use it should get an exception.
-            // Package content files are not available at runtime, they are considered as a part of local cache on build machine.
-            foreach (var package in installedPackages.Packages)
+            foreach (var package in installedPackages.Packages) {
+                // Removing the folder path because it is a build feature and any plugin that is trying to use it should get an exception.
+                // Package content files are not available at runtime, they are considered as a part of local cache on build machine.
                 package.RemoveBuildTimePaths();
+
+                package.ConvertToCrossPlatformPaths();
+            }
 
             return installedPackages;
         }


### PR DESCRIPTION
Replace "/" and "\" to Path.DirectorySeparatorChar when loading `InstalledPackages.json` and `DataMigrationScripts.json`, that allows loading correctly files in disk in cross-platform environment.