### PR TITLE
Updated FastReplacer and FastReplacerSnippet to CPOL 1.02

### DIFF
--- a/src/Rhetos.Core/Utilities/FastReplacer.cs
+++ b/src/Rhetos.Core/Utilities/FastReplacer.cs
@@ -1,20 +1,12 @@
 ﻿/*
-    Copyright (C) 2014 Omega software d.o.o.
+    This code is licensed under the Code Project Open License (CPOL) 1.02.
+    
+    CPOL 1.02 - https://www.codeproject.com/info/cpol10.aspx
+    
+    Originally published at:
+    https://www.codeproject.com/Articles/298519/Fast-Token-Replacement-in-Csharp
 
-    This file is part of Rhetos.
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    By Bojan Antolovic
 */
 
 using System;

--- a/src/Rhetos.Core/Utilities/FastReplacerSnippet.cs
+++ b/src/Rhetos.Core/Utilities/FastReplacerSnippet.cs
@@ -1,20 +1,12 @@
 ﻿/*
-    Copyright (C) 2014 Omega software d.o.o.
+    This code is licensed under the Code Project Open License (CPOL) 1.02.
+    
+    CPOL 1.02 - https://www.codeproject.com/info/cpol10.aspx
+    
+    Originally published at:
+    https://www.codeproject.com/Articles/298519/Fast-Token-Replacement-in-Csharp
 
-    This file is part of Rhetos.
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    By Bojan Antolovic
 */
 
 using System;

--- a/test/Rhetos.Core.Test/Utilities/FastReplacerTest.cs
+++ b/test/Rhetos.Core.Test/Utilities/FastReplacerTest.cs
@@ -1,20 +1,12 @@
 ﻿/*
-    Copyright (C) 2014 Omega software d.o.o.
+    This code is licensed under the Code Project Open License (CPOL) 1.02.
+    
+    CPOL 1.02 - https://www.codeproject.com/info/cpol10.aspx
+    
+    Originally published at:
+    https://www.codeproject.com/Articles/298519/Fast-Token-Replacement-in-Csharp
 
-    This file is part of Rhetos.
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    By Bojan Antolovic
 */
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;


### PR DESCRIPTION
This PR addresses the licensing issue #486 

The original FastReplacer and FastReplacerSnippet code were published on [CodeProject](https://www.codeproject.com/Articles/298519/Fast-Token-Replacement-in-Csharp) with the last update to the code being 2013-09-06. The CPOL license explicitly states that any changes or modifications to the code must retain the same license. Due to this, the license is incompatible with AGPL.

This PR simply updates the comment within the source files to reflect that they are licensed as CPOL as is legally required. 